### PR TITLE
Add sickle (prop-3958) astrometric offset-correction scripts

### DIFF
--- a/brick2221/reduction/build_sickle_gns_offsets.py
+++ b/brick2221/reduction/build_sickle_gns_offsets.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+"""Build the sickle -> GNS offsets table (Offsets_JWST_Brick3958_GNS.csv).
+
+Audit (2026-06-20) found sickle catalogs sit at the RAW assign_wcs frame
+(RAOFFSET=0, no offsets table for 3958): ~91 mas (RA) off the GNS reference the
+mosaics are tied to.  User chose the GNS frame.  This measures the per-filter
+bulk correction sickle->GNS and writes a per-frame offsets table in the
+shift_individual_catalog convention:
+
+    final = centroid - RAOFFSET_meta + dra_table     (RAOFFSET=0 for sickle)
+    want  = centroid + corr_onsky                    (corr = GNS - catalog, mas)
+    => dra_table  = corr_dRA_onsky_arcsec / cos(dec)   (Delta-alpha coordinate)
+       ddec_table = corr_dDec_onsky_arcsec
+
+GNS reference = catalogs/nircam_bootstrapped_to_gns_refcat.fits (dense, covers
+the field; the absolute GNS-tied NIRCam reference the mosaics already use).
+
+Validation: (A) apply the correction to each filter's merged catalog and confirm
+residual vs GNS -> ~0; (B) confirm every crf frame maps to exactly one table row
+(the shift_individual_catalog match.sum()==1 contract).  Writes nothing unless
+both validations pass (unless --force).
+"""
+import sys, os, glob, re, warnings
+warnings.simplefilter('ignore')
+import numpy as np
+import astropy.units as u
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+
+BP = '/orange/adamginsburg/jwst/sickle'
+OUT = f'{BP}/offsets/Offsets_JWST_Brick3958_GNS.csv'
+FILTERS = ['F187N', 'F210M', 'F335M', 'F470N', 'F480M']
+GNS = Table.read(f'{BP}/catalogs/nircam_bootstrapped_to_gns_refcat.fits')
+gns_sc = (SkyCoord(GNS['skycoord']) if 'skycoord' in GNS.colnames
+          else SkyCoord(GNS['RA'], GNS['DEC'], unit='deg'))
+
+
+def bulk_corr(cat_sc):
+    """median on-sky (corr_dRA, corr_dDec) in mas to move cat -> GNS, + n, rms."""
+    idx, sep, _ = cat_sc.match_to_catalog_sky(gns_sc)
+    ridx, _, _ = gns_sc.match_to_catalog_sky(cat_sc)
+    mutual = ridx[idx] == np.arange(len(idx))
+    keep = mutual & (sep.arcsec < 0.3)
+    if keep.sum() < 30:
+        return None
+    c, r = cat_sc[keep], gns_sc[idx[keep]]
+    dra = (r.ra - c.ra).to(u.arcsec).value * np.cos(np.radians(c.dec.deg)) * 1000  # GNS - cat, mas on-sky
+    ddec = (r.dec - c.dec).to(u.arcsec).value * 1000
+    # robust: sigma-clip around the median to kill mismatches
+    m_dra, m_ddec = np.median(dra), np.median(ddec)
+    cl = np.hypot(dra - m_dra, ddec - m_ddec) < 100
+    return (float(np.median(dra[cl])), float(np.median(ddec[cl])),
+            int(cl.sum()), float(np.std(np.hypot(dra[cl] - m_dra, ddec[cl] - m_ddec))))
+
+
+def merged_cat(filt):
+    for tok in ('resbgsub_m7', 'resbgsub_m6', 'resbgsub_m5', 'm4', 'm3', 'm2'):
+        p = sorted(glob.glob(f'{BP}/catalogs/{filt.lower()}_nrcb_indivexp_merged_{tok}_dao_basic_vetted.fits'))
+        if p:
+            return p[-1]
+    return None
+
+
+# ---- 1. measure per-filter correction ----
+corr = {}
+print("Per-filter sickle->GNS bulk correction (median, mas on-sky):")
+for f in FILTERS:
+    mp = merged_cat(f)
+    if not mp:
+        print(f"  {f}: NO merged catalog found -- skip"); continue
+    t = Table.read(mp)
+    sc = SkyCoord(t['skycoord']) if 'skycoord' in t.colnames else SkyCoord(t['ra'], t['dec'], unit='deg')
+    fcol = 'flux' if 'flux' in t.colnames else 'flux_fit'
+    br = np.argsort(-np.asarray(t[fcol], float))[:5000]
+    r = bulk_corr(sc[br])
+    if r is None:
+        print(f"  {f}: <30 GNS matches -- skip"); continue
+    corr[f] = r
+    print(f"  {f}: corr_dRA={r[0]:+.1f}  corr_dDec={r[1]:+.1f}  (n={r[2]}, scatter={r[3]:.0f} mas)  src={os.path.basename(mp)}")
+
+# ---- 2. enumerate crf frames -> table rows ----
+rows = []
+for f in FILTERS:
+    if f not in corr:
+        continue
+    cdra, cddec = corr[f][0], corr[f][1]
+    # representative dec for the cos() term (field center)
+    decc = -28.805
+    dra_tab = (cdra / 1000.0) / np.cos(np.radians(decc))   # arcsec, Delta-alpha
+    ddec_tab = cddec / 1000.0                                # arcsec
+    suffix = 'destreak_o007_crf' if f in ('F187N', 'F210M') else 'align_o007_crf'
+    frames = sorted(glob.glob(f'{BP}/{f}/pipeline/jw03958007*_{suffix}.fits'))
+    seen = set()
+    for fn in frames:
+        bn = os.path.basename(fn)
+        # jw{ppppp}{ooo}{vvv}_{vgroup}_{exp}_{detector}_...  e.g.
+        # jw03958007001_03104_00001_nrcblong_align_o007_crf.fits
+        m = re.match(r'jw(\d{5})(\d{3})(\d{3})_(\w+?)_(\d{5})_(nrc\w+?)_', bn)
+        if not m:
+            continue
+        prop, obs, visit, vgroup, exp, det = m.groups()
+        key = (f, det, int(visit), int(exp))
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(dict(Filter=f, Module=det, Visit=f'jw{prop}{obs}{visit}',
+                         Exposure=int(exp), dra=dra_tab, ddec=ddec_tab,
+                         RAOFFSET_meta=0.0, DEOFFSET_meta=0.0,
+                         corr_dRA_mas=cdra, corr_dDec_mas=cddec))
+    print(f"  {f}: {len(seen)} unique (det,visit,exp) frame rows")
+
+ot = Table(rows)
+print(f"\nTotal offsets-table rows: {len(ot)}")
+
+# ---- 3. VALIDATION A: applying the correction lands the merged catalog on GNS ----
+print("\nVALIDATION A (apply corr -> residual vs GNS, should be ~0):")
+ok_A = True
+for f in corr:
+    mp = merged_cat(f); t = Table.read(mp)
+    sc = SkyCoord(t['skycoord']) if 'skycoord' in t.colnames else SkyCoord(t['ra'], t['dec'], unit='deg')
+    fcol = 'flux' if 'flux' in t.colnames else 'flux_fit'
+    br = np.argsort(-np.asarray(t[fcol], float))[:5000]
+    cdra, cddec = corr[f][0], corr[f][1]
+    decarr = sc[br].dec.deg
+    new = SkyCoord(sc[br].ra + (cdra/1000/np.cos(np.radians(decarr)))*u.arcsec,
+                   sc[br].dec + (cddec/1000)*u.arcsec)
+    r = bulk_corr(new)
+    res = np.hypot(r[0], r[1]) if r else 999
+    flag = 'OK' if res < 5 else 'FAIL'
+    if res >= 5: ok_A = False
+    print(f"  {f}: residual after correction = {r[0]:+.1f},{r[1]:+.1f} mas ({flag})")
+
+# ---- 4. write ----
+if '--force' in sys.argv or ok_A:
+    os.makedirs(f'{BP}/offsets', exist_ok=True)
+    ot.write(OUT, overwrite=True)
+    print(f"\nWROTE {OUT}  ({len(ot)} rows)")
+else:
+    print("\nValidation A FAILED -- not writing (use --force to override)")
+print("BUILD_DONE")

--- a/brick2221/reduction/merge_sickle_miri_o001_o002.py
+++ b/brick2221/reduction/merge_sickle_miri_o001_o002.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Merge sickle MIRI o001 (POS1) + o002 (POS2) into a single per-filter mosaic
+(2026-06-14).
+
+o001 and o002 are adjacent pointings of the same field; both are now correctly
+registered to the NIRCam/F480M frame (o001 was re-reduced with shift-only
+tweakreg, fixing the F1130W 45-deg rotation and F1500W 6.9" shift).  This
+drizzles the per-exposure _align.fits frames of BOTH observations together with
+jwst ResampleStep, producing one combined i2d covering both tiles.
+
+o003 is EXCLUDED: it is the Brick background pointing and is handled with the
+Brick data, not Sickle.
+
+Usage: python merge_sickle_miri_o001_o002.py [F1130W F1500W ...]
+Writes /orange/adamginsburg/jwst/sickle/<FILT>/pipeline/jw03958-o001o002_t001_miri_<filt>_i2d.fits
+"""
+import os
+import sys
+import glob
+import warnings
+warnings.filterwarnings('ignore')
+os.environ.setdefault("CRDS_PATH", "/orange/adamginsburg/jwst/brick/crds/")
+os.environ.setdefault("CRDS_SERVER_URL", "https://jwst-crds.stsci.edu")
+
+from jwst.resample import ResampleStep
+from jwst.datamodels import ModelContainer
+from jwst.datamodels import ImageModel
+
+BASE = '/orange/adamginsburg/jwst/sickle'
+FILTERS = sys.argv[1:] if len(sys.argv) > 1 else ['F1130W', 'F1500W']
+
+
+def main():
+    for filt in FILTERS:
+        pdir = f'{BASE}/{filt}/pipeline'
+        # o001 = jw03958001001_*, o002 = jw03958002001_*  (o003 EXCLUDED)
+        frames = (sorted(glob.glob(f'{pdir}/jw03958001001_*_mirimage_align.fits'))
+                  + sorted(glob.glob(f'{pdir}/jw03958002001_*_mirimage_align.fits')))
+        if not frames:
+            print(f'{filt}: no o001/o002 align frames found; SKIP', flush=True)
+            continue
+        print(f'{filt}: merging {len(frames)} frames '
+              f'({sum("001001" in f for f in frames)} o001 + '
+              f'{sum("002001" in f for f in frames)} o002)', flush=True)
+        models = ModelContainer([ImageModel(f) for f in frames])
+        out = f'{pdir}/jw03958-o001o002_t001_miri_{filt.lower()}_i2d.fits'
+        res = ResampleStep.call(models, output_file=os.path.basename(out),
+                                output_dir=pdir, save_results=True)
+        print(f'{filt}: wrote {out}', flush=True)
+    print('DONE', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/brick2221/reduction/register_o002_f770w_gwcs_to_f480m.py
+++ b/brick2221/reduction/register_o002_f770w_gwcs_to_f480m.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+"""Register the GWCS of each sickle o002 F770W crf frame directly to the NIRCam
+F480M reference catalog (2026-06-13).
+
+WHY: the crf FITS-header WCS was already corrected (per-frame, MIRIDRA), so the
+PSF-photometry catalog is registered.  But the embedded ASDF *gwcs* was NEVER
+corrected, and the resample step (image3 i2d, and the cataloging detection i2d)
+builds mosaics from the gwcs -- so every displayed o002 F770W mosaic is ~3.35"
+off F480M while the catalog underneath is fine.  The user requires astrometry-
+corrected FRAMES, so we fix the gwcs at the source: any resample downstream then
+comes out registered.
+
+Method (offset-histogram, dense-field-safe -- NOT nearest-neighbor): for each
+crf, detect bright sources, project with the CURRENT gwcs, histogram the
+(image - F480M) offsets, take the peak, and adjust_wcs() the gwcs by the negative
+of it (mirroring PipelineMIRI.fix_alignment).  Both the saved ASDF gwcs and the
+FITS header are updated; MIRIGWCS guards against double-application.  Re-measures
+after to confirm the residual collapses to ~0.
+
+Run with the o002 cataloging job STOPPED (it reads these files).  Then re-run
+cataloging so the detection i2d is rebuilt from the corrected gwcs.
+"""
+import os
+import copy
+import glob
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, search_around_sky
+from astropy.stats import mad_std
+import astropy.units as u
+from photutils.detection import DAOStarFinder
+from scipy.ndimage import median_filter
+import warnings
+warnings.filterwarnings('ignore')
+
+os.environ.setdefault("CRDS_PATH", "/orange/adamginsburg/jwst/brick/crds/")
+os.environ.setdefault("CRDS_SERVER_URL", "https://jwst-crds.stsci.edu")
+from jwst.datamodels import ImageModel
+from jwst.tweakreg.utils import adjust_wcs
+
+import sys
+# argv[1] = frame glob (default o002 F770W); argv[2] = FWHM in px (band-dependent)
+FRAMEGLOB = sys.argv[1] if len(sys.argv) > 1 else \
+    '/orange/adamginsburg/jwst/sickle/F770W/pipeline/jw03958002001_*_mirimage_o002_crf.fits'
+REFCAT = '/orange/adamginsburg/jwst/sickle/catalogs/f480m_nrcb_indivexp_merged_resbgsub_m6_dao_basic.fits'
+FWHM_PIX = float(sys.argv[2]) if len(sys.argv) > 2 else 2.445
+MFSIZE = 31
+THR = 5
+SEARCH = 6.0
+MIN_MATCH = 30    # min refine-box peak count to trust the offset (sparse-field guard)
+SHIFT_CAP = 8.0   # max |total applied| arcsec; real MIRI pointing error is < this
+
+
+def load_ref():
+    t = Table.read(REFCAT)
+    if 'skycoord' in t.colnames:
+        return SkyCoord(t['skycoord'])
+    return SkyCoord(t['skycoord_ra'], t['skycoord_dec'], unit='deg')
+
+
+def detect(model):
+    d = model.data
+    mfd = median_filter(np.nan_to_num(d, nan=np.nanmedian(d)), size=MFSIZE)
+    hp = np.nan_to_num(d) - mfd
+    s = DAOStarFinder(threshold=THR * mad_std(hp), fwhm=FWHM_PIX)(hp)
+    if s is None or len(s) == 0:
+        return None, None
+    xcol = 'xcentroid' if 'xcentroid' in s.colnames else 'x_centroid'
+    ycol = 'ycentroid' if 'ycentroid' in s.colnames else 'y_centroid'
+    return np.asarray(s[xcol]), np.asarray(s[ycol])
+
+
+def measure(wcsobj, x, y, refsc):
+    """Offset-histogram (image - ref) arcsec using the gwcs."""
+    sc = wcsobj.pixel_to_world(x, y)
+    good = np.isfinite(sc.ra.deg) & np.isfinite(sc.dec.deg)  # off-frame -> NaN
+    sc = sc[good]
+    if len(sc) < 5:
+        return None, None, len(sc)
+    i_b, i_a, sep, _ = search_around_sky(refsc, sc, SEARCH * u.arcsec)
+    if len(i_a) < 5:
+        return None, None, len(i_a)
+    dra = ((sc.ra[i_a] - refsc.ra[i_b]) * np.cos(sc.dec[i_a].rad)).to(u.arcsec).value
+    ddec = (sc.dec[i_a] - refsc.dec[i_b]).to(u.arcsec).value
+    bins = np.arange(-SEARCH, SEARCH + 0.1, 0.1)
+    H, xe, ye = np.histogram2d(dra, ddec, bins=[bins, bins])
+    pk = np.unravel_index(np.argmax(H), H.shape)
+    cx, cy = 0.5 * (xe[pk[0]] + xe[pk[0] + 1]), 0.5 * (ye[pk[1]] + ye[pk[1] + 1])
+    m = (np.abs(dra - cx) < 0.5) & (np.abs(ddec - cy) < 0.5)
+    return float(np.median(dra[m])), float(np.median(ddec[m])), int(m.sum())
+
+
+def main():
+    refsc = load_ref()
+    print(f'reference {len(refsc)} F480M sources', flush=True)
+    for fn in sorted(glob.glob(FRAMEGLOB)):
+        tag = os.path.basename(fn).split('_mirimage')[0]
+        # Idempotent: always converge the CURRENT gwcs residual to ~0 (so a
+        # re-run after a partial/cos-biased prior correction finishes the job).
+        fa = ImageModel(fn)
+        wcsobj = fa.meta.wcs
+        x, y = detect(fa)
+        if x is None:
+            print(f'{tag}: no detections; SKIP', flush=True)
+            fa.close()
+            continue
+        dra0, ddec0, n = measure(wcsobj, x, y, refsc)
+        if dra0 is None:
+            print(f'{tag}: insufficient matches (n={n}); SKIP', flush=True)
+            fa.close()
+            continue
+        # GUARD 1: too-sparse refine-box peak is unreliable (o001 brick-bg
+        # diverged at n~15-135).  Require a solid peak before touching the WCS.
+        if n < MIN_MATCH:
+            print(f'{tag}: peak only n={n} (< {MIN_MATCH}); too sparse to trust; SKIP',
+                  flush=True)
+            fa.close()
+            continue
+        fa.meta.oldwcs = copy.copy(wcsobj)
+        # adjust_wcs(delta_ra=) shifts CRVAL1 in RA-coordinate, but the measured
+        # offset is TRUE-ANGULAR (includes cos dec).  Divide delta_ra by cos(dec)
+        # and iterate so the cos/linearization residual converges to ~0.
+        tot_ra = tot_de = 0.0
+        ww = wcsobj
+        rdra, rddec = dra0, ddec0
+        best_resid = np.hypot(dra0, ddec0)
+        diverged = False
+        for _ in range(5):
+            cosd = np.cos(np.deg2rad(ww.to_fits()[0]['CRVAL2']))
+            ww_try = adjust_wcs(ww, delta_ra=(-rdra / cosd) * u.arcsec,
+                                delta_dec=(-rddec) * u.arcsec)
+            ntot_ra, ntot_de = tot_ra - rdra, tot_de - rddec
+            r2, rd2, rn = measure(ww_try, x, y, refsc)
+            cur = np.hypot(r2, rd2) if r2 is not None else 1e9
+            # GUARD 2: total shift cap -- a real MIRI pointing error is < 8".
+            # GUARD 3: residual must improve; if it grows, the peak jumped to a
+            # spurious mode (divergence) -- stop and keep the last good ww.
+            if abs(ntot_ra) > SHIFT_CAP or abs(ntot_de) > SHIFT_CAP or cur > best_resid + 0.1:
+                diverged = True
+                print(f'{tag}: DIVERGENCE guard tripped (total=({ntot_ra:+.1f},{ntot_de:+.1f})" '
+                      f'resid {best_resid:.2f}->{cur:.2f}"); keeping last good', flush=True)
+                break
+            ww, tot_ra, tot_de = ww_try, ntot_ra, ntot_de
+            rdra, rddec, best_resid = r2, rd2, cur
+            if abs(rdra) < 0.05 and abs(rddec) < 0.05:
+                break
+        # GUARD 4: if we never applied a safe step (diverged on first try) leave
+        # the file UNTOUCHED rather than write a bad WCS.
+        if diverged and tot_ra == 0.0 and tot_de == 0.0:
+            print(f'{tag}: no safe correction found; LEAVING UNCHANGED', flush=True)
+            fa.close()
+            continue
+        fa.meta.wcs = ww
+        fa.save(fn, overwrite=True)
+        # FITS header sync
+        ah = fits.open(fn)
+        if 'OLCRVA1G' not in ah[1].header:
+            ah[1].header['OLCRVA1G'] = ah[1].header['CRVAL1']
+            ah[1].header['OLCRVA2G'] = ah[1].header['CRVAL2']
+        ah[1].header.update(ww.to_fits()[0])
+        prev = ah[1].header.get('MIRIGWCS', '')
+        ah[1].header['MIRIGWCS'] = (f'{tot_ra:+.3f},{tot_de:+.3f}',
+                                    'gwcs+FITS registered to F480M [arcsec] 2026-06-13')
+        ah.writeto(fn, overwrite=True)
+        fa.close()
+        print(f'{tag}: init offset (image-ref)=({dra0:+.2f},{ddec0:+.2f})" n={n} '
+              f'-> total applied ({tot_ra:+.2f},{tot_de:+.2f})"  '
+              f'final residual=({rdra:+.2f},{rddec:+.2f})"', flush=True)
+    print('DONE', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/brick2221/reduction/register_o002_f770w_per_frame_to_f480m.py
+++ b/brick2221/reduction/register_o002_f770w_per_frame_to_f480m.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""Per-frame astrometric registration of sickle prop-3958 o002 F770W crf frames
+directly to the NIRCam F480M reference catalog (2026-06-13).
+
+WHY: MIRI tweakreg (abs_searchrad=0.4") cannot bridge the ~2-6" per-dither
+pointing error of these frames, so it silently fails and every crf keeps its raw
+commanded pointing.  A prior UNIFORM correction (MIRIDRA=3.33, MIRIDDE=-1.37)
+was applied to all 5 frames, but the true error is PER-FRAME (offset-histogram vs
+F480M: |off| 2.3-6.2", direction varies), so per-frame residuals remain and the
+o002 catalog sits ~3-4" off truth (0/36 hand-selected captured).
+
+This bypasses tweakreg: for each crf, detect bright sources, offset-histogram the
+(image - F480M) offsets (dense-field-safe; nearest-neighbor median is meaningless
+here), and subtract the peak from the FITS-header WCS (CRVAL).  FITS-only, matching
+apply_measured_miri_wcs_offsets.py: the manual cataloging pipeline reads the FITS
+WCS (cataloging.py: ``wcs.WCS(im1[1].header)``).  MIRIDRA/MIRIDDE are updated
+CUMULATIVELY (old applied + new residual) so the keyword always records the total
+correction vs the original commanded WCS.
+
+Run, then re-run o002 cataloging and re-score hand-selected capture.
+"""
+import os
+import glob
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, search_around_sky
+from astropy.stats import mad_std
+import astropy.units as u
+from photutils.detection import DAOStarFinder
+from scipy.ndimage import median_filter
+import warnings
+warnings.filterwarnings('ignore')
+
+FRAMEGLOB = '/orange/adamginsburg/jwst/sickle/F770W/pipeline/jw03958002001_*_mirimage_o002_crf.fits'
+REFCAT = '/orange/adamginsburg/jwst/sickle/catalogs/f480m_nrcb_indivexp_merged_resbgsub_m6_dao_basic.fits'
+FWHM_PIX = 2.445   # F770W at 0.11"/px
+MFSIZE = 31
+THR = 5
+SEARCH = 6.0       # arcsec
+
+
+def load_ref():
+    t = Table.read(REFCAT)
+    if 'skycoord' in t.colnames:
+        return SkyCoord(t['skycoord'])
+    return SkyCoord(t['skycoord_ra'], t['skycoord_dec'], unit='deg')
+
+
+def measure_offset(fn, refsc):
+    """Offset-histogram (image - ref) in arcsec from the current FITS WCS."""
+    fh = fits.open(fn)
+    d = fh['SCI'].data
+    ww = WCS(fh['SCI'].header)
+    mfd = median_filter(np.nan_to_num(d, nan=np.nanmedian(d)), size=MFSIZE)
+    hp = np.nan_to_num(d) - mfd
+    s = DAOStarFinder(threshold=THR * mad_std(hp), fwhm=FWHM_PIX)(hp)
+    if s is None or len(s) == 0:
+        return None, None, 0
+    xcol = 'xcentroid' if 'xcentroid' in s.colnames else 'x_centroid'
+    ycol = 'ycentroid' if 'ycentroid' in s.colnames else 'y_centroid'
+    sc = ww.pixel_to_world(s[xcol], s[ycol])
+    i_b, i_a, sep, _ = search_around_sky(refsc, sc, SEARCH * u.arcsec)
+    if len(i_a) < 5:
+        return None, None, len(i_a)
+    dra = ((sc.ra[i_a] - refsc.ra[i_b]) * np.cos(sc.dec[i_a].rad)).to(u.arcsec).value
+    ddec = (sc.dec[i_a] - refsc.dec[i_b]).to(u.arcsec).value
+    bins = np.arange(-SEARCH, SEARCH + 0.1, 0.1)
+    H, xe, ye = np.histogram2d(dra, ddec, bins=[bins, bins])
+    pk = np.unravel_index(np.argmax(H), H.shape)
+    cx, cy = 0.5 * (xe[pk[0]] + xe[pk[0] + 1]), 0.5 * (ye[pk[1]] + ye[pk[1] + 1])
+    m = (np.abs(dra - cx) < 0.5) & (np.abs(ddec - cy) < 0.5)
+    return float(np.median(dra[m])), float(np.median(ddec[m])), int(m.sum())
+
+
+def apply(fn, dra_as, ddec_as):
+    """Subtract (image - ref) residual from FITS CRVAL; update MIRIDRA cumulatively."""
+    fh = fits.open(fn)
+    h = fh[1].header
+    cosd = np.cos(np.deg2rad(h['CRVAL2']))
+    prev_ra = float(h.get('MIRIDRA', 0.0))
+    prev_de = float(h.get('MIRIDDE', 0.0))
+    if 'OLCRVAL1' not in h:
+        h['OLCRVAL1'] = h['CRVAL1']
+        h['OLCRVAL2'] = h['CRVAL2']
+    h['CRVAL1'] = h['CRVAL1'] - dra_as / 3600. / cosd
+    h['CRVAL2'] = h['CRVAL2'] - ddec_as / 3600.
+    # MIRIDRA records TOTAL applied correction (= -(image-ref)) vs commanded WCS
+    h['MIRIDRA'] = (prev_ra + (-dra_as), 'total applied RA corr [arcsec], per-frame 2026-06-13')
+    h['MIRIDDE'] = (prev_de + (-ddec_as), 'total applied Dec corr [arcsec], per-frame 2026-06-13')
+    h['MIRIWCSN'] = ('FITS WCS corrected per-frame to F480M; ASDF gwcs NOT corrected',
+                     'offset-histogram registration')
+    fh.writeto(fn, overwrite=True)
+
+
+def main():
+    refsc = load_ref()
+    print(f'reference {len(refsc)} F480M sources', flush=True)
+    for fn in sorted(glob.glob(FRAMEGLOB)):
+        tag = os.path.basename(fn).split('_mirimage')[0]
+        dra, ddec, n = measure_offset(fn, refsc)
+        if dra is None:
+            print(f'{tag}: insufficient matches (n={n}); SKIP', flush=True)
+            continue
+        apply(fn, dra, ddec)
+        print(f'{tag}: residual (image-ref)=({dra:+.2f}",{ddec:+.2f}") n={n} '
+              f'-> applied ({-dra:+.2f}",{-ddec:+.2f}")', flush=True)
+    print('DONE', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/brick2221/reduction/register_sickle_miri_o001_o002.py
+++ b/brick2221/reduction/register_sickle_miri_o001_o002.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""
+Register sickle MIRI o001/o002 (POS1/POS2) products to the NIRCam refcat frame
+(2026-06-13).
+
+o003 (brick-bg) was WCS-corrected earlier (apply_measured_miri_wcs_offsets.py)
+but o001/o002 were not -- they carry the legacy hard-coded MIRI shift, leaving
+them offset from the F480M/NIRCam refcat frame (o001 F770W measured +2.63",
+-1.74" via offset-histogram).  This corrects the FITS WCS (CRVAL) of every
+o001/o002 product -- the per-frame _cal/_align/_crf files used by cataloging AND
+the i2d mosaics -- for all three MIRI filters, using the per-obs offset measured
+on F770W (same pointing/shift for all filters of an obs).  Idempotent via MIRIDRA.
+
+OFFSETS (filled from the offset-histogram measurement; obs -> (dRA,dDec) arcsec,
+F770W-minus-refcat; correction subtracts these):
+"""
+import os
+import glob
+import sys
+import numpy as np
+from astropy.io import fits
+import warnings
+warnings.filterwarnings('ignore')
+
+# obs -> (dRA, dDec) in arcsec, measured F770W image-minus-refcat
+OFFSETS = {
+    '001': (float(sys.argv[1]), float(sys.argv[2])),
+    '002': (float(sys.argv[3]), float(sys.argv[4])),
+}
+FILTERS = ['F770W', 'F1130W', 'F1500W']
+BASE = '/orange/adamginsburg/jwst/sickle'
+
+
+def correct(fn, dra, ddec):
+    # safety guard: never apply an implausible offset (sentinel / typo).  MIRI
+    # registration shifts are a few arcsec; anything >30" is garbage.
+    if not (np.isfinite(dra) and np.isfinite(ddec) and abs(dra) < 30 and abs(ddec) < 30):
+        return 'skip'
+    fh = fits.open(fn)
+    # find the SCI (or only-image) HDU index
+    hidx = None
+    for i, h in enumerate(fh):
+        if h.name == 'SCI' or (h.data is not None and getattr(h, 'data', None) is not None and h.data.ndim == 2):
+            hidx = i
+            if h.name == 'SCI':
+                break
+    if hidx is None:
+        fh.close(); return False
+    hd = fh[hidx].header
+    if 'CRVAL1' not in hd:
+        fh.close(); return False
+    if 'MIRIDRA' in hd:
+        fh.close(); return 'skip'
+    cosd = np.cos(np.deg2rad(hd['CRVAL2']))
+    hd['OLCRVAL1'] = hd['CRVAL1']
+    hd['OLCRVAL2'] = hd['CRVAL2']
+    hd['CRVAL1'] = hd['CRVAL1'] - dra / 3600.0 / cosd
+    hd['CRVAL2'] = hd['CRVAL2'] - ddec / 3600.0
+    hd['MIRIDRA'] = (-dra, 'applied RA correction [arcsec] 2026-06-13')
+    hd['MIRIDDE'] = (-ddec, 'applied Dec correction [arcsec] 2026-06-13')
+    hd['MIRIWCSN'] = ('FITS WCS corrected; ASDF gwcs NOT corrected',
+                      'offset-histogram registration to NIRCam refcat')
+    fh.writeto(fn, overwrite=True)
+    return True
+
+
+for obs, (dra, ddec) in OFFSETS.items():
+    for filt in FILTERS:
+        pdir = f'{BASE}/{filt}/pipeline'
+        pats = [f'{pdir}/jw03958{obs}001_*_mirimage_cal.fits',
+                f'{pdir}/jw03958{obs}001_*_mirimage_align.fits',
+                f'{pdir}/jw03958-o{obs}*_mirimage_o{obs}_crf.fits',
+                f'{pdir}/jw03958{obs}001_*_mirimage_o{obs}_crf.fits',
+                f'{pdir}/jw03958-o{obs}_t00?_miri_*{filt.lower()}*i2d.fits',
+                f'{pdir}/jw03958-o{obs}_t00?_miri_*{filt.lower()}*data_i2d.fits']
+        files = sorted(set(f for p in pats for f in glob.glob(p)))
+        n_ok = n_skip = 0
+        for fn in files:
+            r = correct(fn, dra, ddec)
+            if r == 'skip':
+                n_skip += 1
+            elif r:
+                n_ok += 1
+        print(f'o{obs} {filt}: corrected {n_ok}, already-done {n_skip} '
+              f'(offset {dra:+.3f},{ddec:+.3f}")', flush=True)
+print('ALL DONE')

--- a/brick2221/shellscripts/brick_miri_f2550w_reduce_o002.sh
+++ b/brick2221/shellscripts/brick_miri_f2550w_reduce_o002.sh
@@ -12,6 +12,9 @@
 # CAL_VER 1.14.1 / 2024-05-07 (2-year-stale calibration); the rightmost mosaic
 # tile shows artifacts/speckle.  Re-reduce with the current pipeline + good
 # outlier params (marshall OFF -> subtract=True, snr 30/25), same as w51.
+# EAST trim is now ADAPTIVE (per-frame glow detection) -- leave MIRI_TRIM_EAST
+# unset (floor=0) so clean east edges (e.g. visit-001 _08/10/12101 covering the
+# detector-gap notch) are preserved while glowing frames are trimmed.
 cd /orange/adamginsburg/jwst/brick
 /blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python \
     /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \

--- a/brick2221/shellscripts/sgrb2_miri_f1280w_cataloging_joint_o002_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f1280w_cataloging_joint_o002_o998.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --job-name=webb-cat-sgrb2-F1280W-joint-o002o998
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/webb-cat-sgrb2-F1280W-joint-o002o998_%j.log
+
+# JOINT MIRI F1280W cataloging of sgrb2 (prop 5365) obs 002 + obs 998 together.
+# The 4 mosaic tiles (002: 0210b/02105, 998: 06101/12101) tile the full Sgr B2
+# field; --field=002-998 globs BOTH obs's crf so the merged data_i2d / residual /
+# model span all four -> the correct combined product (the per-obs run showed
+# only half).  Worktree miri-joint-satstar (satstar + fake-bright gate + data_i2d
+# on reduction-mosaic grid).  Reuses crf from the standard-tree reduction.
+WT=/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline-wt-miri-joint
+export PYTHONPATH="$WT:$PYTHONPATH"
+cd /orange/adamginsburg/jwst/sgrb2
+rm -f F1280W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_catalog.fits \
+      F1280W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_model*.fits \
+      F1280W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_flags*.fits \
+      F1280W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_residual*.fits 2>/dev/null
+/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python \
+    "$WT/jwst_gc_pipeline/photometry/crowdsource_catalogs_long.py" \
+    --filternames=F1280W --modules=mirimage --each-exposure \
+    --proposal_id=5365 --field=002-998 --target=sgrb2 \
+    --each-suffix=o002_crf \
+    --daophot --skip-crowdsource \
+    --parallel-workers=4 \
+    --group --max-group-size=10 --manual-group-min-sep-fwhm=3.0

--- a/brick2221/shellscripts/sgrb2_miri_f1280w_reduce_o002_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f1280w_reduce_o002_o998.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=sgrb2-F1280W-o002o998-PipelineMIRI
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/sgrb2-F1280W-o002o998-PipelineMIRI_%j.log
+
+# Full re-reduction of sgrb2 (prop 5365) F1280W obs 002 + obs 998 from scratch
+# in the STANDARD tree (sgrb2/F1280W/pipeline).  F770W/F1280W previously existed
+# only under nbudaiev's sgrb2/NB/ tree (old daophot, no satstar); user opted to
+# re-reduce cleanly in our pipeline.  No -s: downloads uncal + image3 asn from
+# MAST, then Detector1 -> Image2 -> Image3 (adaptive east trim, relative align,
+# no abs refcat -- same as F2550W obs002).  obs002 first, then obs998, sequential
+# (shared filter dir -> avoid mastDownload relocate race).  Then joint-catalog
+# --field=002-998.
+cd /orange/adamginsburg/jwst/sgrb2
+PY=/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python
+echo "===== F1280W obs002 ====="
+$PY /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \
+    -f F1280W -d 002 -p 5365
+echo "===== F1280W obs998 ====="
+$PY /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \
+    -f F1280W -d 998 -p 5365

--- a/brick2221/shellscripts/sgrb2_miri_f2550w_cataloging_joint_o002_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f2550w_cataloging_joint_o002_o998.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --job-name=webb-cat-sgrb2-F2550W-joint-o002o998
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/webb-cat-sgrb2-F2550W-joint-o002o998_%j.log
+
+# JOINT MIRI F2550W cataloging of sgrb2 (prop 5365) obs 002 + obs 998 together.
+# The 4 mosaic tiles (002: 0210b/02105, 998: 06101/12101) tile the full Sgr B2
+# field; --field=002-998 globs BOTH obs's crf so the merged data_i2d / residual /
+# model span all four -> the correct combined product (the per-obs run showed
+# only half).  Worktree miri-joint-satstar (satstar + fake-bright gate + data_i2d
+# on reduction-mosaic grid).  Reuses crf from the standard-tree reduction.
+WT=/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline-wt-miri-joint
+export PYTHONPATH="$WT:$PYTHONPATH"
+cd /orange/adamginsburg/jwst/sgrb2
+rm -f F2550W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_catalog.fits \
+      F2550W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_model*.fits \
+      F2550W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_flags*.fits \
+      F2550W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_residual*.fits 2>/dev/null
+/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python \
+    "$WT/jwst_gc_pipeline/photometry/crowdsource_catalogs_long.py" \
+    --filternames=F2550W --modules=mirimage --each-exposure \
+    --proposal_id=5365 --field=002-998 --target=sgrb2 \
+    --each-suffix=o002_crf \
+    --daophot --skip-crowdsource \
+    --parallel-workers=4 \
+    --group --max-group-size=10 --manual-group-min-sep-fwhm=3.0

--- a/brick2221/shellscripts/sgrb2_miri_f2550w_reduce_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f2550w_reduce_o998.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH --job-name=sgrb2-F2550W-o998-PipelineMIRI
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/sgrb2-F2550W-o998-PipelineMIRI_%j.log
+
+# Reduce sgrb2 (prop 5365) obs 998 ("Sgr B2 MIRI_skipped_redo") F2550W -> crf.
+# obs998 (tiles 06101+12101) is the MISSING HALF of the sgrb2 MIRI mosaic: obs002
+# (0210b+02105) was already reduced+cataloged, but obs998 sat at cal with no crf.
+# -s reuses the existing 10 cal files (Detector1/Image2 already done).  East
+# trim is adaptive (per-frame glow).  After this -> joint-catalog --field=002-998.
+cd /orange/adamginsburg/jwst/sgrb2
+/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python \
+    /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \
+    -f F2550W -d 998 -p 5365 -s

--- a/brick2221/shellscripts/sgrb2_miri_f770w_cataloging_joint_o002_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f770w_cataloging_joint_o002_o998.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --job-name=webb-cat-sgrb2-F770W-joint-o002o998
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/webb-cat-sgrb2-F770W-joint-o002o998_%j.log
+
+# JOINT MIRI F770W cataloging of sgrb2 (prop 5365) obs 002 + obs 998 together.
+# The 4 mosaic tiles (002: 0210b/02105, 998: 06101/12101) tile the full Sgr B2
+# field; --field=002-998 globs BOTH obs's crf so the merged data_i2d / residual /
+# model span all four -> the correct combined product (the per-obs run showed
+# only half).  Worktree miri-joint-satstar (satstar + fake-bright gate + data_i2d
+# on reduction-mosaic grid).  Reuses crf from the standard-tree reduction.
+WT=/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline-wt-miri-joint
+export PYTHONPATH="$WT:$PYTHONPATH"
+cd /orange/adamginsburg/jwst/sgrb2
+rm -f F770W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_catalog.fits \
+      F770W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_model*.fits \
+      F770W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_flags*.fits \
+      F770W/pipeline/jw05365*_mirimage_*o[09][09][28]_crf*satstar_residual*.fits 2>/dev/null
+/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python \
+    "$WT/jwst_gc_pipeline/photometry/crowdsource_catalogs_long.py" \
+    --filternames=F770W --modules=mirimage --each-exposure \
+    --proposal_id=5365 --field=002-998 --target=sgrb2 \
+    --each-suffix=o002_crf \
+    --daophot --skip-crowdsource \
+    --parallel-workers=4 \
+    --group --max-group-size=10 --manual-group-min-sep-fwhm=3.0

--- a/brick2221/shellscripts/sgrb2_miri_f770w_reduce_o002_o998.sh
+++ b/brick2221/shellscripts/sgrb2_miri_f770w_reduce_o002_o998.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=sgrb2-F770W-o002o998-PipelineMIRI
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96gb
+#SBATCH --time=48:00:00
+#SBATCH --output=/blue/adamginsburg/adamginsburg/logs/miri_phot/sgrb2-F770W-o002o998-PipelineMIRI_%j.log
+
+# Full re-reduction of sgrb2 (prop 5365) F770W obs 002 + obs 998 from scratch
+# in the STANDARD tree (sgrb2/F770W/pipeline).  F770W/F1280W previously existed
+# only under nbudaiev's sgrb2/NB/ tree (old daophot, no satstar); user opted to
+# re-reduce cleanly in our pipeline.  No -s: downloads uncal + image3 asn from
+# MAST, then Detector1 -> Image2 -> Image3 (adaptive east trim, relative align,
+# no abs refcat -- same as F2550W obs002).  obs002 first, then obs998, sequential
+# (shared filter dir -> avoid mastDownload relocate race).  Then joint-catalog
+# --field=002-998.
+cd /orange/adamginsburg/jwst/sgrb2
+PY=/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python
+echo "===== F770W obs002 ====="
+$PY /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \
+    -f F770W -d 002 -p 5365
+echo "===== F770W obs998 ====="
+$PY /orange/adamginsburg/repos/jwst-gc-pipeline/jwst_gc_pipeline/reduction/PipelineMIRI.py \
+    -f F770W -d 998 -p 5365

--- a/brick2221/shellscripts/sickle_gns_reduce_retry.sh
+++ b/brick2221/shellscripts/sickle_gns_reduce_retry.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Submit the sickle GNS re-reduction array when the group QOS frees (it is
+# currently saturated -> submit fails with QOSGrpCpuLimit).  On success: chain
+# the already-submitted per-filter cataloging jobs behind their filter's
+# reduction task (afterok) and RELEASE them (they were held to prevent the crf
+# read/write collision + premature raw-frame cataloging).  Reduction applies the
+# GNS fix_alignment branch + SW=destreak/LW=align policy; crf names match what
+# cataloging --each-suffix consumes.
+set -u
+cd /blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline
+PR=/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline
+declare -A CAT=( [0]=35364681 [1]=35364682 [2]=35364683 [3]=35364684 [4]=35364685 )
+FIN=35364686
+LOG=$PR/_bench/sickle_gns_reduce_retry.log
+echo "RETRY start $(date -u +%FT%TZ)" | tee -a "$LOG"
+while true; do
+    OUT=$(sbatch --parsable --array=0-4 \
+        --account=astronomy-dept --qos=astronomy-dept-b \
+        --export=ALL,PROPOSAL=3958,FIELD=007,MODULES=nrcb,FILTERS="F187N F210M F335M F470N F480M",PIPE_ROOT=$PR \
+        scripts/reduction/submit_reduction.sbatch 2>&1)
+    if [[ "$OUT" =~ ^[0-9]+$ ]]; then
+        R=${OUT%%;*}
+        echo "REDUCTION SUBMITTED R=$R at $(date -u +%FT%TZ)" | tee -a "$LOG"
+        for i in 0 1 2 3 4; do
+            scontrol update jobid=${CAT[$i]} dependency=afterok:${R}_${i} 2>&1 | tee -a "$LOG"
+            scontrol release ${CAT[$i]} 2>&1 | tee -a "$LOG"
+        done
+        scontrol release $FIN 2>&1 | tee -a "$LOG"
+        echo "RETRY done: reduction=$R, cataloging chained+released" | tee -a "$LOG"
+        break
+    fi
+    echo "submit blocked ($(echo "$OUT" | tr '\n' ' ' | cut -c1-80)); retry in 10m $(date -u +%FT%TZ)" >> "$LOG"
+    sleep 600
+done


### PR DESCRIPTION
Region-specific sickle astrometry provenance, moved out of jwst-gc-pipeline (region-general pipeline repo) per review.

`reduction/`: `build_sickle_gns_offsets.py` (sickle->GNS ~91 mas table read by fix_alignment), `register_sickle_miri_o001_o002.py`, `register_o002_f770w_per_frame_to_f480m.py`, `register_o002_f770w_gwcs_to_f480m.py`, `merge_sickle_miri_o001_o002.py`.
`shellscripts/`: `sickle_gns_reduce_retry.sh`.

Paired with jwst-gc-pipeline PR #11 (which removes these + keeps the region-general regression tests).

Generated with Claude Code