### PR TITLE
Brick module-locked rerun tooling: pipeline runner, union catalog, VVV reference

### DIFF
--- a/brick2221/analysis/build_union_locked.py
+++ b/brick2221/analysis/build_union_locked.py
@@ -1,0 +1,115 @@
+"""
+Build the full 1182+2221 UNION multiband catalog from the per-filter module-locked
+(VIRAC2-tied) combined catalogs.
+
+Replaces the stale `basic_merged_indivexp_..._ok2221or1182` merge (built on the old
+per-detector-tweakreg positions -> within-1182 quiltwork + cross-program offset). All
+10 per-filter inputs here are `<filt>_merged_indivexp_LOCKED_dao_basic.fits`, each one
+module-locked (one rigid shift per visit, all detectors) and tied to VIRAC2 PM-propagated
+to the observation epoch, so they share one absolute astrometric frame (to the ~12 mas
+cross-program filter-distortion floor; F182M vs F200W is the worst case).
+
+Method: union cross-match (same logic as merge_catalogs.merge_catalogs but on the already-
+combined per-filter products, not per-frame). Start from the reference filter, then for each
+other filter add its unmatched (mutual-NN, sep>radius) sources to the master coordinate list.
+Then attach every filter's columns matched to the master coords, masked where sep>radius.
+
+Output: catalogs/union_merged_indivexp_LOCKED_ok2221or1182_dao_basic.fits
+
+Per-filter columns: flux_<f>, std_ra_mas_<f>, std_dec_mas_<f>, nframes_<f>, qfit_<f>,
+is_saturated_<f>, sep_<f> (arcsec to master), ra_<f>, dec_<f>, det_<f> (bool: detected).
+Master: skycoord (master position = ref-filter position where matched, else first filter that
+added the source), ndet (number of filters detecting the source), ref_filter (which filter
+contributed the master position).
+"""
+import sys
+import numpy as np
+from astropy.table import Table, MaskedColumn
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+CD = '/orange/adamginsburg/jwst/brick/catalogs'
+# union order: deepest/broadest first so the master frame is anchored on F200W (1182 SW).
+ORDER = ['f200w', 'f115w', 'f356w', 'f444w', 'f182m', 'f212n', 'f410m', 'f187n', 'f405n', 'f466n']
+RADIUS = 0.10 * u.arcsec
+PROP = {'f115w': '1182', 'f200w': '1182', 'f356w': '1182', 'f444w': '1182',
+        'f182m': '2221', 'f187n': '2221', 'f212n': '2221',
+        'f405n': '2221', 'f410m': '2221', 'f466n': '2221'}
+CARRY = ['flux', 'std_ra_mas', 'std_dec_mas', 'nframes', 'qfit', 'is_saturated']
+
+
+def load(filt):
+    t = Table.read(f'{CD}/{filt}_merged_indivexp_LOCKED_dao_basic.fits')
+    return t, SkyCoord(t['skycoord'])
+
+
+def main():
+    filts = [f for f in ORDER if __import__('os').path.exists(
+        f'{CD}/{f}_merged_indivexp_LOCKED_dao_basic.fits')]
+    missing = [f for f in ORDER if f not in filts]
+    if missing:
+        print(f"WARNING: missing LOCKED catalogs, skipping: {missing}", flush=True)
+
+    tabs = {}
+    scs = {}
+    for f in filts:
+        t, sc = load(f)
+        tabs[f] = t
+        scs[f] = sc
+        print(f"loaded {f}: {len(t)} ({PROP[f]})", flush=True)
+
+    # ---- build master coordinate list (union) ----
+    ref = filts[0]
+    master = scs[ref]
+    origin = np.array([ref] * len(master), dtype='U6')
+    print(f"\nmaster start: {ref} ({len(master)})", flush=True)
+    for f in filts[1:]:
+        sc = scs[f]
+        idx, sep, _ = sc.match_to_catalog_sky(master)
+        ridx, _, _ = master.match_to_catalog_sky(sc)
+        mutual = ridx[idx] == np.arange(len(idx))
+        add = (sep > RADIUS) | (~mutual)
+        newsc = sc[add]
+        master = SkyCoord([master, newsc])
+        origin = np.concatenate([origin, np.array([f] * len(newsc), dtype='U6')])
+        print(f"  + {f}: added {add.sum()} -> master {len(master)}", flush=True)
+
+    out = Table()
+    out['skycoord'] = master
+    out['RA'] = master.ra.deg
+    out['DEC'] = master.dec.deg
+    out['ref_filter'] = origin
+    ndet = np.zeros(len(master), int)
+
+    # ---- attach each filter matched to master ----
+    for f in filts:
+        sc = scs[f]
+        t = tabs[f]
+        idx, sep, _ = master.match_to_catalog_sky(sc)
+        ridx, _, _ = sc.match_to_catalog_sky(master)
+        mutual = ridx[idx] == np.arange(len(idx))
+        det = (sep < RADIUS) & mutual
+        ndet += det.astype(int)
+        out[f'det_{f}'] = det
+        out[f'sep_{f}'] = sep.to(u.arcsec).value
+        out[f'ra_{f}'] = MaskedColumn(sc.ra.deg[idx], mask=~det)
+        out[f'dec_{f}'] = MaskedColumn(sc.dec.deg[idx], mask=~det)
+        for c in CARRY:
+            if c in t.colnames:
+                out[f'{c}_{f}'] = MaskedColumn(np.asarray(t[c])[idx], mask=~det)
+        print(f"attach {f}: {det.sum()} detections matched to master", flush=True)
+
+    out['ndet'] = ndet
+    out.meta['CONTENT'] = 'union 1182+2221 multiband, module-locked VIRAC2-tied per-filter inputs'
+    out.meta['INPUTS'] = ','.join(filts)
+    out.meta['RADIUS_AS'] = RADIUS.to(u.arcsec).value
+    out.meta['REFFRAME'] = 'VIRAC2 PM-propagated to obs epoch (per-filter LOCKED); ~12mas cross-program floor'
+    outpath = f'{CD}/union_merged_indivexp_LOCKED_ok2221or1182_dao_basic.fits'
+    out.write(outpath, overwrite=True)
+    print(f"\nwrote {outpath}: {len(out)} rows, {len(out.colnames)} cols", flush=True)
+    for n in range(1, len(filts) + 1):
+        print(f"  ndet>={n}: {(ndet >= n).sum()}", flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/brick2221/analysis/build_vvv_hband_mosaic.py
+++ b/brick2221/analysis/build_vvv_hband_mosaic.py
@@ -1,0 +1,98 @@
+"""
+Build a single VVV H-band reference mosaic over the whole GC JWST footprint.
+
+VVV Ks deep imaging is unavailable from HiPerGator (CASU VSA / ROE unreachable; no Ks
+HiPS exists). The CDS VVV DR4 H/Bulge HiPS (~0.2"/pix) covers the GC bulge and is the
+reachable real-image substitute -- H-band shows the same bright stars as Ks (only the
+most reddened sources differ), which is what we need to spot bright stars just outside
+each JWST FOV.
+
+At 0.25"/pix the GC footprint is ~1.4 Gpix, too large for one hips2fits request, so we
+define ONE global TAN WCS and render it in tiles (each tile is a window into the global
+frame -> pixel grids align exactly), assembling a single mosaic FITS.
+
+Output: /orange/adamginsburg/jwst/vvv/vvv_dr4_Hband_GC_mosaic_0p25.fits
+"""
+import os
+import numpy as np
+from astropy.wcs import WCS
+from astropy.io import fits
+from astroquery.hips2fits import hips2fits
+from astropy import units as u
+
+HIPS = 'CDS/P/VISTA/VVV/DR4/H/Bulge'
+OUTDIR = '/orange/adamginsburg/jwst/vvv'
+OUT = f'{OUTDIR}/vvv_dr4_Hband_GC_mosaic_0p25.fits'
+
+# Global frame: TAN centered on the GC, covering all GC JWST fields
+# (Sgr C l~359.4, Sgr A* l~0.0, Arches/Quintuplet, Brick l~0.25, Sgr B2 l~0.67).
+CRVAL = (266.45, -28.90)            # deg, center
+PIXSCALE = 0.25 / 3600.0           # deg/pix
+HALF_X_DEG = 0.62                  # angular half-width  (x)  -> ~RA 265.8..267.1
+HALF_Y_DEG = 0.78                  # angular half-height (y)  -> Dec -29.68..-28.12
+TILE = 2000                       # render tile size (pix); larger -> server read-timeout
+
+hips2fits.timeout = 300           # CDS render+transfer can be slow for big tiles
+
+
+def global_wcs():
+    nx = int(np.ceil(2 * HALF_X_DEG / PIXSCALE))
+    ny = int(np.ceil(2 * HALF_Y_DEG / PIXSCALE))
+    w = WCS(naxis=2)
+    w.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    w.wcs.crval = list(CRVAL)
+    w.wcs.crpix = [nx / 2.0 + 0.5, ny / 2.0 + 0.5]
+    w.wcs.cd = [[-PIXSCALE, 0.0], [0.0, PIXSCALE]]
+    w.wcs.cunit = ['deg', 'deg']
+    return w, nx, ny
+
+
+def tile_wcs(gw, x0, y0, tnx, tny):
+    """sub-WCS = global WCS with CRPIX shifted so (x0,y0) is the tile origin."""
+    w = gw.deepcopy()
+    w.wcs.crpix = [gw.wcs.crpix[0] - x0, gw.wcs.crpix[1] - y0]
+    w.array_shape = (tny, tnx)
+    return w
+
+
+def main():
+    os.makedirs(OUTDIR, exist_ok=True)
+    gw, nx, ny = global_wcs()
+    print(f"global frame {nx} x {ny} = {nx*ny/1e6:.0f} Mpix ({nx*ny*4/1e9:.2f} GB float32)", flush=True)
+    mosaic = np.full((ny, nx), np.nan, dtype='float32')
+
+    ntx = int(np.ceil(nx / TILE)); nty = int(np.ceil(ny / TILE))
+    print(f"{ntx} x {nty} = {ntx*nty} tiles", flush=True)
+    k = 0
+    for jy in range(nty):
+        y0 = jy * TILE; tny = min(TILE, ny - y0)
+        for ix in range(ntx):
+            x0 = ix * TILE; tnx = min(TILE, nx - x0)
+            k += 1
+            tw = tile_wcs(gw, x0, y0, tnx, tny)
+            for attempt in range(4):
+                try:
+                    hdu = hips2fits.query_with_wcs(hips=HIPS, wcs=tw, format='fits',
+                                                   get_query_payload=False)
+                    data = hdu[0].data if isinstance(hdu, fits.HDUList) else hdu.data
+                    mosaic[y0:y0+tny, x0:x0+tnx] = np.asarray(data, dtype='float32')
+                    nvalid = np.isfinite(data).sum()
+                    print(f"  tile {k}/{ntx*nty} [{x0}:{x0+tnx},{y0}:{y0+tny}] ok, {nvalid/1e6:.1f}Mpix valid", flush=True)
+                    break
+                except Exception as e:
+                    print(f"  tile {k} attempt {attempt} ERR {repr(e)[:160]}", flush=True)
+                    if attempt == 3:
+                        print(f"  tile {k} FAILED, leaving NaN", flush=True)
+
+    hdr = gw.to_header()
+    hdr['BUNIT'] = 'arbitrary'
+    hdr['SURVEY'] = 'VVV DR4'
+    hdr['BAND'] = 'H'
+    hdr['HIPS'] = HIPS
+    hdr['COMMENT'] = 'VVV DR4 H-band GC reference mosaic rendered from CDS HiPS via hips2fits'
+    fits.PrimaryHDU(data=mosaic, header=hdr).writeto(OUT, overwrite=True)
+    print(f"wrote {OUT} ({os.path.getsize(OUT)/1e9:.2f} GB)", flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/brick2221/shellscripts/run_full_pipeline_brick.sh
+++ b/brick2221/shellscripts/run_full_pipeline_brick.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run_full_pipeline_brick.sh -- full BRICK reduction + cataloging chain on the
+# NEW module-locked VIRAC2 astrometric reference (Offsets_JWST_Brick<prop>_VIRAC2locked.csv).
+#
+# Brick is two proposals reduced into the same tree (/orange/adamginsburg/jwst/brick):
+#   1182 obs 004 : broadband  F115W F200W F356W F444W
+#   2221 obs 001 : narrowband F182M F187N F212N F405N F410M F466N
+#
+# Per filter:
+#   1) REDUCTION (Image3) with --skip_step1and2 : reuse up-to-date *_cal.fits
+#      (Detector1/Image2 are alignment-independent), regenerate *_destreak.fits
+#      fresh -> fix_alignment applies the per-VISIT module-locked offset
+#      (tweakreg is skip:True so the lock is preserved) -> fresh *_destreak_o<F>_crf
+#      + *_i2d on the new reference.
+#   2) CATALOGING through m7 via submit_manual_pipeline.sh (manual-iteration
+#      m12->m3->m4->m5->m6->m7), one multi-filter job per proposal (engages the
+#      m7 cross-band seed), dependent on that proposal's reduction jobs.
+#
+# fix_alignment is idempotent on the RAOFFSET header, but the *_destreak.fits it
+# writes to is regenerated fresh each run, so the new offsets ARE applied (the old
+# RAOFFSET lived only on the previous destreak/crf, which Image3 overwrites).
+#
+# Usage:
+#   run_full_pipeline_brick.sh            # submit everything
+#   run_full_pipeline_brick.sh --dry-run  # print the sbatch commands only
+#   TAG=V11 run_full_pipeline_brick.sh    # override cataloging tag (default V10)
+#
+set -euo pipefail
+
+DRYRUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRYRUN=1
+
+PYTHON=/blue/adamginsburg/adamginsburg/miniconda3/envs/python313/bin/python
+PIPELINE=/orange/adamginsburg/repos/brick-jwst-2221/brick2221/reduction/PipelineRerunNIRCAM-LONG.py
+CATLAUNCH=/orange/adamginsburg/repos/brick-jwst-2221/brick2221/shellscripts/submit_manual_pipeline.sh
+CRDS_PATH=${CRDS_PATH:-/orange/adamginsburg/jwst/crds}
+LOGDIR=/blue/adamginsburg/adamginsburg/brick_logs
+TAG=${TAG:-V10}
+mkdir -p "${LOGDIR}"
+
+# Cataloging resource caps.  The auto-sizer in submit_manual_pipeline.sh scales
+# CPUS to the frame count (->128) and MEM=CPUS*6 (->768gb), which never schedules
+# on astronomy-dept-b.  The 2026-04 streaming merge refactor dropped the merge
+# peak to ~30 GB, so CPU was the only real driver: cap to a schedulable size.
+# Override via env (CAT_CPUS / CAT_MEM).
+export MANUAL_CPUS=${CAT_CPUS:-32}
+export MANUAL_MEM=${CAT_MEM:-192gb}
+
+# proposal : field : filters(csv) : cataloging-launcher-target
+P1182="1182:004:F115W,F200W,F356W,F444W:brick-1182"
+P2221="2221:001:F182M,F187N,F212N,F405N,F410M,F466N:brick"
+
+submit_reduction() {
+  # $1 proposal_id  $2 field  $3 filter
+  local prop="$1" field="$2" filt="$3"
+  local wrap="CRDS_PATH=${CRDS_PATH} CRDS_SERVER_URL=https://jwst-crds.stsci.edu ${PYTHON} ${PIPELINE} --proposal_id=${prop} --field=${field} --filternames=${filt} --modules=merged --skip_step1and2"
+  if (( DRYRUN )); then
+    echo "sbatch [reduction ${prop}/${field}/${filt}]: ${wrap}" >&2
+    echo "REDU_${prop}_${filt}_DRYJOB"
+    return
+  fi
+  sbatch --parsable \
+    --account=astronomy-dept --qos=astronomy-dept-b \
+    --ntasks=8 --nodes=1 --mem=256gb --time=96:00:00 \
+    --job-name="webb-pipe-brick-${prop}-${filt}" \
+    --output="${LOGDIR}/webb-pipe-brick-${prop}-${filt}_%j.log" \
+    --wrap "${wrap}"
+}
+
+run_side() {
+  # $1 = "prop:field:filters:cattarget"
+  IFS=':' read -r prop field filters cattarget <<< "$1"
+  echo "=== BRICK ${cattarget} (prop ${prop}, field ${field}): ${filters} ===" >&2
+  local -a redu_ids=()
+  local f
+  for f in ${filters//,/ }; do
+    jid=$(submit_reduction "${prop}" "${field}" "${f}")
+    redu_ids+=("${jid}")
+    echo "  reduction ${f}: ${jid}" >&2
+  done
+  local dep; dep=$(IFS=:; echo "${redu_ids[*]}")
+  echo "  cataloging (m12..m7) depends on: ${dep}" >&2
+  if (( DRYRUN )); then
+    echo "  ${CATLAUNCH} ${cattarget} ${filters} merged ${TAG} ${dep}"
+  else
+    "${CATLAUNCH}" "${cattarget}" "${filters}" merged "${TAG}" "${dep}"
+  fi
+}
+
+run_side "${P1182}"
+run_side "${P2221}"
+echo "ALL BRICK PIPELINE JOBS SUBMITTED (tag ${TAG})." >&2


### PR DESCRIPTION
New tooling from the brick module-locked VIRAC2 astrometric rerun.

## Added
- **`brick2221/shellscripts/run_full_pipeline_brick.sh`** -- chains per-filter Image3 reduction (`--skip_step1and2`, reusing up-to-date cal) into m12->m7 cataloging on the module-locked VIRAC2 reference. Caps cataloging at 32 CPU / 192 GB so it schedules on `astronomy-dept-b` (the auto-sizer's 128 CPU / 768 GB never did).
- **`brick2221/analysis/build_union_locked.py`** -- cross-matches the 10 per-filter module-locked (VIRAC2-tied) catalogs into one 1182+2221 union, replacing the stale crowdsource-era `ok2221or1182` merge.
- **`brick2221/analysis/build_vvv_hband_mosaic.py`** -- renders a whole-GC VVV DR4 H-band reference mosaic (0.25"/pix) from the CDS HiPS via hips2fits. Ks deep imaging is unavailable (VSA unreachable, no Ks HiPS); H shows the same bright stars for spotting saturators just outside each JWST FOV.

## Context
Reductions + cataloging (m12->m7) for all 10 brick bands were re-run on the new per-visit module-locked offsets. The cataloging-memory fixes (seed-clip, bg-crop, fix_alignment Visit&Filter match) live in jwst-gc-pipeline and are already committed there.

Generated with Claude Code