### PR TITLE
Fix self-perpetuating ~0 VIRAC2 astrometry tie (brick 1182)

### DIFF
--- a/brick2221/analysis/build_virac2_locked_perexp.py
+++ b/brick2221/analysis/build_virac2_locked_perexp.py
@@ -31,7 +31,7 @@ import sys, glob, os, re, argparse
 import numpy as np
 import astropy.units as u
 from astropy.table import Table, vstack
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, search_around_sky
 from astropy.stats import mad_std
 import warnings
 warnings.filterwarnings('ignore')
@@ -40,6 +40,89 @@ V2EP = 2014.0
 SEARCH = 0.3 * u.arcsec
 CLIP_MAS = 60.0
 CLUSTER_MAS = 50.0
+# Coarse per-visit bulk tie: large-radius crowding-robust search (cross-correlation
+# peak), NOT nearest-neighbour. A nearest-neighbour match with radius SEARCH cannot
+# recover an offset larger than SEARCH: in a dense field every star has a chance
+# neighbour within SEARCH, so the median collapses to ~0 and the visit is left
+# UNcorrected (silently). This was the brick-1182 recurrence: the old coarse bridge
+# was taken from each catalog's previously-applied RAOFFSET, which was itself ~0, so
+# every rebuild re-confirmed ~0. COARSE_MAXSEP must exceed the largest expected raw
+# guide-star pointing error (~2" for brick); QA_FAIL_MAS rejects a bad solve.
+COARSE_MAXSEP = 5.0 * u.arcsec   # >= largest expected raw pointing error (1182 ~1.94"); headroom is cheap on clean i2d input
+COARSE_BIN = 0.08          # arcsec, coarse-histogram bin (refined by the SEARCH fine step)
+COARSE_MIN_PEAK_RATIO = 5.0  # i2d xcorr peak/background below this -> tie ambiguous, fail loud
+
+
+def coarse_xcorr(sc, ref, maxsep=COARSE_MAXSEP, binarc=COARSE_BIN):
+    """Robust bulk COORDINATE offset (arcsec Delta-alpha/Delta-delta, NO cosd) to ADD to
+    ``sc`` to land on ``ref``, via the peak of the 2-D histogram of ALL pairs within
+    ``maxsep``.  Crowding-proof and recovers offsets up to ``maxsep`` (unlike a
+    nearest-neighbour match, which cannot see past its own radius) -- PROVIDED the input
+    is a clean, high-SNR source list.  Returns (dra, ddec, npairs, peak, bg) or
+    (None,)*5 if too few pairs.
+
+    NB: must be fed CLEAN positions (drizzled-mosaic detections), NOT raw per-frame
+    SIAF positions: per-detector SIAF residuals smear the per-frame pair-peak below the
+    chance-pair background (measured brick 1182: per-frame peak/bg~1.5, i2d peak/bg~55).
+    """
+    ia, ib, sep, _ = search_around_sky(sc, ref, maxsep)
+    if len(ia) < 50:
+        return None, None, None, None, None
+    dra = (ref[ib].ra - sc[ia].ra).to(u.arcsec).value
+    ddec = (ref[ib].dec - sc[ia].dec).to(u.arcsec).value
+    m = maxsep.to(u.arcsec).value
+    bins = np.arange(-m, m + binarc, binarc)
+    H, xe, ye = np.histogram2d(dra, ddec, bins=[bins, bins])
+    i, j = np.unravel_index(H.argmax(), H.shape)
+    bg = float(np.median(H[H > 0])) if (H > 0).any() else 0.0
+    return ((xe[i] + xe[i + 1]) / 2.0, (ye[j] + ye[j + 1]) / 2.0,
+            len(ia), float(H.max()), bg)
+
+
+def detect_i2d_sources(i2d_path, thr=80.0, fwhm=2.5):
+    """Bright high-SNR source SkyCoords from a drizzled mosaic (for the coarse tie)."""
+    from astropy.io import fits
+    from astropy.wcs import WCS
+    from astropy.stats import sigma_clipped_stats
+    from photutils.detection import DAOStarFinder
+    sci = fits.open(i2d_path)['SCI']
+    w = WCS(sci.header)
+    d = sci.data.astype('float32')
+    _, med, std = sigma_clipped_stats(d, sigma=3.0)
+    t = DAOStarFinder(fwhm=fwhm, threshold=thr * std)(d - med)
+    return SkyCoord(w.pixel_to_world(t['xcentroid'], t['ycentroid']))
+
+
+def coarse_from_i2d(filt, rc, ref):
+    """Per-FILTER coarse bulk tie measured on the drizzled mosaic (clean) vs VIRAC2.
+    This seeds every visit of the filter; the per-visit/per-exposure fine NN then
+    resolves the <SEARCH residual.  Returns (dra, ddec) arcsec to ADD, or None."""
+    sub = rc['filts'][filt][0]
+    i2d = (f"{rc['basepath']}/{sub}/pipeline/"
+           f"jw0{rc['proposal']}-o{rc['field']}_t001_nircam_clear-{filt}-merged_i2d.fits")
+    if not os.path.exists(i2d):
+        print(f"  [coarse] no i2d for {filt}: {i2d}")
+        return None
+    sc = detect_i2d_sources(i2d)
+    dra, ddec, n, peak, bg = coarse_xcorr(sc, ref)
+    if dra is None:
+        print(f"  [coarse] {filt}: too few i2d pairs"); return None
+    ratio = peak / bg if bg > 0 else np.inf
+    if ratio < COARSE_MIN_PEAK_RATIO:
+        print(f"  [coarse] {filt}: peak/bg {ratio:.1f} < {COARSE_MIN_PEAK_RATIO} -> ambiguous, refusing")
+        return None
+    # refine the histogram coarse (bin-limited ~half-bin) to mas precision with a fine NN
+    # on the CLEAN i2d detections themselves (now within <SEARCH of VIRAC2, so the NN finds
+    # real counterparts, not chance) -- removes the coarse-bin dependence of the final tie.
+    shifted = SkyCoord((sc.ra.deg + dra / 3600.0) * u.deg, (sc.dec.deg + ddec / 3600.0) * u.deg)
+    fine = coord_shift(shifted.ra.deg, shifted.dec.deg, ref)
+    if fine is not None:
+        dra += fine[0]; ddec += fine[1]
+    print(f"  [coarse] {filt}: i2d tie ADD=({dra:+.4f},{ddec:+.4f})\" "
+          f"npairs={n} peak/bg={peak:.0f}/{bg:.0f}={ratio:.1f} "
+          f"i2dfine=({(fine[0]*1000 if fine else 0):+.1f},{(fine[1]*1000 if fine else 0):+.1f})mas "
+          f"({len(sc)} i2d srcs)", flush=True)
+    return dra, ddec
 
 # region -> proposal/field/basepath + {filt: (subdir, obs-epoch, mtag)}
 REGION = {
@@ -135,18 +218,34 @@ def lock_filter(filt, rc):
             ra, dec, ra0, de0 = load_siaf(f)
             byve[(vis, exp)][0].append(ra); byve[(vis, exp)][1].append(dec)
             byv[vis].append((ra, dec)); coarse[vis][0].append(ra0); coarse[vis][1].append(de0)
+    # PER-FILTER coarse bulk tie, measured ONCE on the clean drizzled mosaic vs VIRAC2.
+    # This replaces the old per-visit coarse that was sourced from each catalog's
+    # previously-applied RAOFFSET -- which, when ~0 (brick 1182), left the fine NN unable
+    # to recover the real ~2" offset and the table self-perpetuated at ~0 every rebuild.
+    # The i2d source list is high-SNR (peak/bg~55 vs ~1.5 for raw per-frame SIAF), so the
+    # xcorr peak is unambiguous; the per-visit/per-exposure fine NN below resolves the
+    # remaining <SEARCH residual.  FAIL LOUD if the mosaic tie is not clean.
+    i2d_coarse = coarse_from_i2d(filt, rc, ref)
+    if i2d_coarse is None:
+        raise SystemExit(f"[FAIL] {filt}: could not measure a clean i2d coarse tie; "
+                         f"refusing to write a lock table (would re-perpetuate ~0).")
+    c_ra, c_dec = i2d_coarse
     rows = []
     for vis in sorted(byv):
-        c_ra = float(np.median(coarse[vis][0])); c_dec = float(np.median(coarse[vis][1]))
+        # legacy coarse (median of previously-applied RAOFFSET) -- diagnostic only.
+        c_ra_legacy = float(np.median(coarse[vis][0])); c_dec_legacy = float(np.median(coarse[vis][1]))
         consensus = build_consensus(byv[vis])
         cc_ra = consensus.ra.deg + c_ra / 3600.0; cc_dec = consensus.dec.deg + c_dec / 3600.0
         res = coord_shift(cc_ra, cc_dec, ref)
         if res is None:
-            print(f"  visit{vis}: bulk fine tie failed (coarse {c_ra:.3f},{c_dec:.3f})"); continue
+            # coarse alone (no per-visit fine refinement available)
+            res = (0.0, 0.0, 0.0, 0.0, 0)
+            print(f"  visit{vis}: fine tie weak; using i2d coarse alone")
         bulk_ra = c_ra + res[0]; bulk_dec = c_dec + res[1]
-        print(f"  visit{vis}: coarse({c_ra:.4f},{c_dec:.4f})\" + fine({res[0]*1000:+.1f},{res[1]*1000:+.1f})mas "
-              f"=> BULK ({bulk_ra:.4f},{bulk_dec:.4f})\" SEM {res[2]:.2f}/{res[3]:.2f}mas n={res[4]}; "
-              f"consensus={len(consensus)}", flush=True)
+        print(f"  visit{vis}: i2d_coarse({c_ra:+.4f},{c_dec:+.4f})\" [legacy {c_ra_legacy:+.4f},"
+              f"{c_dec_legacy:+.4f}] + fine({res[0]*1000:+.1f},{res[1]*1000:+.1f})mas "
+              f"=> BULK ({bulk_ra:.4f},{bulk_dec:.4f})\" SEM {res[2]:.2f}/{res[3]:.2f}mas "
+              f"n={res[4]}; consensus={len(consensus)}", flush=True)
         for exp in sorted(e for (v, e) in byve if v == vis):
             ra = np.concatenate(byve[(vis, exp)][0]); dec = np.concatenate(byve[(vis, exp)][1])
             rel = coord_shift(ra, dec, consensus)

--- a/brick2221/analysis/verify_1182_astrometry.py
+++ b/brick2221/analysis/verify_1182_astrometry.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Verify (BY IMAGE, not table) that the re-drizzled brick i2d are tied to the
+absolute VIRAC2 frame.  Success = each filter's drizzled mosaic, and the
+1182-vs-2221 cross-filter offset, are < THRESH_MAS via a crowding-robust
+cross-correlation (peak of the 2-D pair-separation histogram).  A 0.1" nearest-
+neighbour match MUST NOT be used here -- in this dense field it returns chance
+coincidences whose median is ~0 and hides a multi-arcsec offset.
+
+Usage: verify_1182_astrometry.py [--release]   (--release checks the staged copies)
+"""
+import argparse, numpy as np, astropy.units as u
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, search_around_sky
+from photutils.detection import DAOStarFinder
+from astropy.stats import sigma_clipped_stats
+
+BASE = "/orange/adamginsburg/jwst/brick"
+REFCAT = f"{BASE}/catalogs/gaia_virac2_refcat_epoch2022.70.fits"
+THRESH_MAS = 50.0
+# (filter, proposal, pipeline-relative i2d path)
+TARGETS = [
+    ("F115W", 1182, "F115W/pipeline/jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits"),
+    ("F200W", 1182, "F200W/pipeline/jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits"),
+    ("F356W", 1182, "F356W/pipeline/jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits"),
+    ("F444W", 1182, "F444W/pipeline/jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits"),
+    ("F212N", 2221, "F212N/pipeline/jw02221-o001_t001_nircam_clear-f212n-merged_i2d.fits"),
+    ("F182M", 2221, "F182M/pipeline/jw02221-o001_t001_nircam_clear-f182m-merged_i2d.fits"),
+]
+
+
+def detect(path):
+    sci = fits.open(path)["SCI"]; w = WCS(sci.header); d = sci.data.astype("float32")
+    _, med, std = sigma_clipped_stats(d, sigma=3.0)
+    t = DAOStarFinder(fwhm=2.5, threshold=80 * std)(d - med)
+    return SkyCoord(w.pixel_to_world(t["xcentroid"], t["ycentroid"]))
+
+
+def xcorr(a, b, maxsep=2.5, binarc=0.04):
+    ia, ib, _, _ = search_around_sky(a, b, maxsep * u.arcsec)
+    dra = (a[ia].ra - b[ib].ra).to(u.arcsec).value * np.cos(a[ia].dec.radian)
+    ddec = (a[ia].dec - b[ib].dec).to(u.arcsec).value
+    bins = np.arange(-maxsep, maxsep + binarc, binarc)
+    H, xe, ye = np.histogram2d(dra, ddec, bins=[bins, bins])
+    i, j = np.unravel_index(H.argmax(), H.shape)
+    return (xe[i] + xe[i + 1]) / 2, (ye[j] + ye[j + 1]) / 2, H.max() / max(np.median(H[H > 0]), 1)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--release", action="store_true",
+                    help="check the staged release copies instead of the pipeline products")
+    args = ap.parse_args()
+    refc = SkyCoord(Table.read(REFCAT)["RA"], Table.read(REFCAT)["DEC"], unit=u.deg)
+    cats, ok = {}, True
+    print(f"{'filter':7s}{'prop':6s}{'offset vs VIRAC2':>22s}{'peak/bg':>9s}  verdict")
+    for filt, prop, rel in TARGETS:
+        path = (f"/orange/adamginsburg/jwst/releases/v1.0-2026.06/brick/images/{filt}/"
+                + rel.split('/')[-1]) if args.release else f"{BASE}/{rel}"
+        sc = detect(path); cats[filt] = sc
+        dr, dd, pk = xcorr(sc, refc)
+        off = np.hypot(dr, dd) * 1000
+        good = off < THRESH_MAS
+        ok &= good
+        print(f"{filt:7s}{prop:<6d}  dRA={dr:+.3f} dDec={dd:+.3f} |{off:5.0f}mas|{pk:8.0f}x  "
+              f"{'OK' if good else 'FAIL'}")
+    # 1182 vs 2221 cross-filter
+    dr, dd, _ = xcorr(cats["F200W"], cats["F212N"])
+    cross = np.hypot(dr, dd) * 1000
+    ok &= cross < THRESH_MAS
+    print(f"\n1182(F200W) vs 2221(F212N): |{cross:.0f} mas|  {'OK' if cross < THRESH_MAS else 'FAIL'}")
+    print(f"\n{'ALL PASS' if ok else 'FAILURES PRESENT'} (threshold {THRESH_MAS:.0f} mas)")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
+++ b/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
@@ -34,6 +34,11 @@ export MIRI_SATSTAR_SEED_CONC_MIN=1.1
 # unrecoverable.  Correcting it lets daophot fit the embedded stars-on-emission
 # normally and leaves only the genuine bright cores to the satstar channel.
 export MIRI_FIRSTGROUP_SAT_DQ=1
+# Neighbour-robust daophot prominence gate: recovers faint point sources on
+# bright emission that the median+MAD prominence (miri_prominence_snr=5) drops
+# because a bright neighbour inflates the annulus MAD (cloudc: last 6 by-eye
+# stars, prominence 1.7-4.8). Robust 25th-pct floor + lower-half spread.
+export MIRI_DAOPHOT_PROM_ROBUST=1
 cd /orange/adamginsburg/jwst/cloudc
 rm -f F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_catalog.fits \
       F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_model*.fits \

--- a/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
+++ b/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
@@ -14,6 +14,19 @@
 # cataloging script's field_to_reg_mapping/obs_filters/nvisits carry 2526->cloudc.
 WT=/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline-wt-miri-joint
 export PYTHONPATH="$WT:$PYTHONPATH"
+
+# Satstar seed-gate recalibration for the cloudc 2526 filament (faint saturated
+# stars, real wing-ring cores 300-760 -- the Sickle-calibrated core>=1000 default
+# discards them; 28 by-eye-real stars were missing from every catalog product).
+# Lower the core floor + enable the neighbour-robust prominence so emission in
+# the annulus doesn't crush real stars below the gate.  --deblend-satstars splits
+# the giant merged DQ-saturated blob (15086 px) that buries ~10 of the 28.
+# Starting values; tune against regions_/f770w_byeyereal_20260629.reg.
+# See project_cloudc_f770w_satstar_gate_miscalib.
+export MIRI_SATSTAR_SEED_PROM_ROBUST=1
+export MIRI_SATSTAR_SEED_CORE_MIN=250
+export MIRI_SATSTAR_SEED_PROM_MIN=6
+export MIRI_SATSTAR_SEED_CONC_MIN=1.1
 cd /orange/adamginsburg/jwst/cloudc
 rm -f F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_catalog.fits \
       F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_model*.fits \
@@ -25,5 +38,6 @@ rm -f F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_catalog.fits \
     --proposal_id=2526 --field=021 --target=cloudc \
     --each-suffix=o021_crf \
     --daophot --skip-crowdsource \
+    --deblend-satstars \
     --parallel-workers=4 \
     --group --max-group-size=10 --manual-group-min-sep-fwhm=3.0

--- a/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
+++ b/brick2221/shellscripts/cloudc_2526_g0_f770w_cataloging_o021.sh
@@ -27,6 +27,13 @@ export MIRI_SATSTAR_SEED_PROM_ROBUST=1
 export MIRI_SATSTAR_SEED_CORE_MIN=250
 export MIRI_SATSTAR_SEED_PROM_MIN=6
 export MIRI_SATSTAR_SEED_CONC_MIN=1.1
+# First-group SATURATED DQ correction: the cal/crf SATURATED flag marks pixels
+# saturated in ANY ramp group, flooding the bright filament (62705 px / one
+# 16231-px DQ blob fusing many real stars) though the ramp fitter recovers their
+# flux; only first-group-saturated pixels (720 px / 26 genuine cores) are truly
+# unrecoverable.  Correcting it lets daophot fit the embedded stars-on-emission
+# normally and leaves only the genuine bright cores to the satstar channel.
+export MIRI_FIRSTGROUP_SAT_DQ=1
 cd /orange/adamginsburg/jwst/cloudc
 rm -f F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_catalog.fits \
       F770W/pipeline/jw02526021001_*_mirimage_*o021_crf*satstar_model*.fits \

--- a/brick2221/shellscripts/rerun_stale_fields.sh
+++ b/brick2221/shellscripts/rerun_stale_fields.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# rerun_stale_fields.sh -- rerun the GC-pipeline fields that were stale and NOT
+# already in the SLURM queue, on CURRENT jwst-gc-pipeline code (so the products
+# get m8 forced-fill + dedup + a GCPIPEV provenance stamp).
+#
+# Context (2026-06-29): a GCPIPEV/staleness audit found most products predated the
+# Jun-27 provenance hook (GCPIPEV=NONE) and lacked m8.  The PM campaign (gc2211,
+# sgra, arches, quintuplet, w51, sickle, sgrb2) was already rerunning from the
+# jwst-gc-pipeline-wt-pm worktree; this script covers the REST.
+#
+# Mechanism: the jwst-gc-pipeline low-resource chain (submit_cataloging_chain.sh
+# = per-filter m12..m6 array + m7 cross-band finalize; the m7 finalize auto-runs
+# m8 + dedup).  Reductions are only re-run where the on-disk reduction predates
+# the Jun-24/28 reduction fixes.  PIPE_ROOT pins the running code (-> GCPIPEV).
+#
+# Depth per field (see the stale-field audit):
+#   cloudc            m7->m8 (m6 already current)
+#   cloudef, wd2      m6->m8 (reuse existing reduction)
+#   sgrc, wd1         full re-reduction -> cataloging
+#   brick 1182/2221   re-catalog from the Jun-20 module-locked crf (keeps the
+#                     locked VIRAC2 astrometry, adds m8 on current code).  Brick
+#                     is TWO single-proposal runs sharing one data tree, unioned
+#                     downstream by merge_catalogs _ok2221or1182 -- NOT one job.
+#                     (Canonical re-reduce+m7 runner: run_full_pipeline_brick.sh.)
+#
+# Suffix note: cloudc/wd2 carry both align_* and destreak_* crf; the documented
+# convention (jwst_gc_pipeline _resolve_each_suffix) is SW=destreak, LW=align,
+# applied here via --each-suffix-overrides.  VERIFY against a canonical product.
+#
+# Usage:
+#   rerun_stale_fields.sh             # submit everything
+#   rerun_stale_fields.sh --dry-run   # print sbatch commands only
+#   PIPE_ROOT=/path/to/checkout rerun_stale_fields.sh
+set -uo pipefail
+
+PIPE_ROOT=${PIPE_ROOT:-/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline}
+export PIPE_ROOT
+R="$PIPE_ROOT/scripts/reduction"
+DRY=0; [[ "${1:-}" == "--dry-run" ]] && DRY=1
+SB() { if (( DRY )); then echo "sbatch $*" >&2; echo "DRYJOB"; else sbatch "$@"; fi; }
+COMMIT=$(git -C "$PIPE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)
+echo "### PIPE_ROOT=$PIPE_ROOT @ $COMMIT  dry=$DRY"
+
+# m7+m8 finalize only (m6 on disk).  $1 target $2 prop $3 field $4 filters
+# $5 each_suffix $6 overrides(csv, may be empty)
+m7_only() {
+    local T=$1 P=$2 F=$3 FILT=$4 SFX=$5 OV=$6
+    [ -n "$OV" ] && export EXTRA_ARGS="--each-suffix-overrides=$OV" || export EXTRA_ARGS=""
+    local EXP="ALL,PROPOSAL=$P,FIELD=$F,TARGET=$T,MODULES=merged,EACH_SUFFIX=$SFX"
+    EXP="$EXP,FILTERS=$FILT,PARALLEL_WORKERS=4,PIPE_ROOT=$PIPE_ROOT"
+    local J; J=$(SB --parsable --job-name="${T}-catalog-m7" \
+        --cpus-per-task=4 --mem=64gb --time=24:00:00 \
+        --export="$EXP" "$R/submit_cataloging_m7.sbatch")
+    echo "  $T m7+m8 -> $J"; unset EXTRA_ARGS
+}
+
+# Full cataloging chain (m12..m6 array + m7/m8).  Extra trailing args -> chain env.
+chain() {
+    local T=$1 P=$2 F=$3 FILT=$4 SFX=$5 OV=$6; shift 6
+    [ -n "$OV" ] && export EXTRA_ARGS="--each-suffix-overrides=$OV" || export EXTRA_ARGS=""
+    echo "  $T cataloging chain"
+    TARGET="$T" PROPOSAL="$P" FIELD="$F" MODULES=merged EACH_SUFFIX="$SFX" \
+        FILTERS="$FILT" PIPE_ROOT="$PIPE_ROOT" "$@" \
+        bash "$R/submit_cataloging_chain.sh" | sed 's/^/    /'
+    unset EXTRA_ARGS
+}
+
+# Full re-reduction array; echoes the array job id (for an afterok chain dep).
+reduce() {
+    local P=$1 F=$2 FILT=$3 T=$4
+    read -r -a _A <<< "$FILT"
+    # MODULES omitted: nrca,nrcb,merged is the sbatch default and a comma value
+    # inside --export is split by SLURM (comma trap).
+    SB --parsable --array=0-$(( ${#_A[@]} - 1 )) \
+        --export="ALL,PROPOSAL=$P,FIELD=$F,FILTERS=$FILT,PIPE_ROOT=$PIPE_ROOT" \
+        --job-name="${T}-reduce" "$R/submit_reduction.sbatch"
+}
+
+echo "== cloudc  (m7->m8) =="
+m7_only cloudc 2221 002 "F182M F187N F212N F405N F410M F466N" destreak_o002_crf \
+    "F405N:align_o002_crf,F410M:align_o002_crf,F466N:align_o002_crf"
+
+echo "== cloudef  (m6->m8) =="
+chain cloudef 2092 002 "F162M F210M F360M F480M" destreak_o002_crf ""
+
+echo "== wd2  (m6->m8; SW=destreak/LW=align) =="
+chain wd2 3523 005 \
+ "F115W F150W F162M F164N F182M F187N F200W F212N F250M F277W F300M F323N F335M F405N F410M F444W F466N" \
+ destreak_o005_crf \
+ "F250M:align_o005_crf,F277W:align_o005_crf,F300M:align_o005_crf,F323N:align_o005_crf,F335M:align_o005_crf,F405N:align_o005_crf,F410M:align_o005_crf,F444W:align_o005_crf,F466N:align_o005_crf"
+
+echo "== sgrc  (re-reduce -> catalog) =="
+SGRC=$(reduce 4147 012 "F115W F162M F182M F212N F360M F405N F470N F480M" sgrc)
+echo "  sgrc reduction -> $SGRC"
+chain sgrc 4147 012 "F115W F162M F182M F212N F360M F405N F470N F480M" destreak_o012_crf "" DEP="afterok:$SGRC"
+
+echo "== wd1  (re-reduce -> catalog) =="
+WD1=$(reduce 1905 001 "F115W F150W F164N F187N F200W F212N F277W F323N F405N F444W F466N" wd1)
+echo "  wd1 reduction -> $WD1"
+chain wd1 1905 001 "F115W F150W F164N F187N F200W F212N F277W F323N F405N F444W F466N" destreak_o001_crf "" DEP="afterok:$WD1"
+
+# Brick: re-catalog from the existing module-locked crf (no re-reduction).  Two
+# single-proposal chains; dense broadband -> 8cpu/48h.
+echo "== brick 1182/004  (re-catalog locked crf) =="
+chain brick 1182 004 "F115W F200W F356W F444W" destreak_o004_crf "" \
+    PERFILTER_CPUS=8 PERFILTER_MEM=96gb PERFILTER_TIME=48:00:00
+
+echo "== brick 2221/001  (re-catalog locked crf) =="
+chain brick 2221 001 "F182M F187N F212N F405N F410M F466N" destreak_o001_crf "" \
+    PERFILTER_CPUS=8 PERFILTER_MEM=96gb PERFILTER_TIME=48:00:00
+
+echo "### DONE.  Already-in-queue (do NOT duplicate): gc2211 sgra arches quintuplet w51 sickle sgrb2."


### PR DESCRIPTION
## Problem
Released brick **jw01182** mosaics (F115W/F200W/F356W/F444W) are **~1.9″ off** the absolute VIRAC2 frame; jw02221 are correct; the merged catalog is correct. Recurring "2″ between 1182 and 2221" bug.

**Root cause:** `build_virac2_locked_perexp.py` solved each visit's coarse bulk tie from the catalog's *previously-applied* `RAOFFSET`, refined by a **0.3″ nearest-neighbour** match. In the crowded Brick field a 0.3″ NN cannot recover an offset larger than its radius — chance neighbours give median ≈ 0 — and with the coarse bridge itself ~0, the solve **self-perpetuated at ~0 on every rebuild**. `fix_alignment` then applied ~0, so the 1182 i2d stayed 1.9″ off while the catalog (tied in table space) stayed correct.

## Fix
- Coarse per-filter tie now from the **clean drizzled i2d** via a ±5″ cross-correlation (pair-histogram peak — crowding-proof, peak/bg ≈ 44–130 vs ≈1.5 for raw per-frame SIAF), refined to mas with a fine NN on the i2d; per-visit/exposure fine NN adds the differential. Independent of any prior offset → re-runs no longer revert.
- **Fail-loud** if the i2d peak is ambiguous (peak/bg < 5).
- Rebuilt `Brick1182_VIRAC2locked.csv`: all 4 filters tie to **(1.886, 0.979)″ ± 15 mas** (was ~0.004″).
- Adds `verify_1182_astrometry.py`: image-level check (i2d vs VIRAC2 and 1182-vs-2221 < 50 mas, robust xcorr — not a 0.1″ NN).

## Follow-ups (not in this PR)
Same 0.3″ trap in `lock_exposures.py` / `relock_exposures.py`; make the `fix_alignment` RAOFFSET guard value-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJqGJt6dT3ZxQbyc4g2zbJ