### PR TITLE
fix: per-visit coarse tie so large-pointing-error visits aren't mislocked (brick-1182 visit001)

### DIFF
--- a/brick2221/analysis/build_virac2_locked_perexp.py
+++ b/brick2221/analysis/build_virac2_locked_perexp.py
@@ -48,9 +48,15 @@ CLUSTER_MAS = 50.0
 # was taken from each catalog's previously-applied RAOFFSET, which was itself ~0, so
 # every rebuild re-confirmed ~0. COARSE_MAXSEP must exceed the largest expected raw
 # guide-star pointing error (~2" for brick); QA_FAIL_MAS rejects a bad solve.
-COARSE_MAXSEP = 5.0 * u.arcsec   # >= largest expected raw pointing error (1182 ~1.94"); headroom is cheap on clean i2d input
+COARSE_MAXSEP = 5.0 * u.arcsec   # per-FILTER i2d seed radius; refined per-visit below
 COARSE_BIN = 0.08          # arcsec, coarse-histogram bin (refined by the SEARCH fine step)
 COARSE_MIN_PEAK_RATIO = 5.0  # i2d xcorr peak/background below this -> tie ambiguous, fail loud
+# PER-VISIT coarse radius.  MUST exceed the largest raw per-visit guide-star pointing
+# error, NOT the ~2" once thought: brick-1182 visit001 is ~22" off (-17.5"/+13.5") while
+# visit002 is ~2".  The single mosaic-wide COARSE_MAXSEP seed captures only the dominant
+# visit; the other visit needs its OWN large-radius histogram xcorr (below) or it silently
+# inherits the dominant visit's shift (the 2026-07 brick-1182 visit001 corruption).
+COARSE_MAXSEP_VISIT = 25.0 * u.arcsec
 
 
 def coarse_xcorr(sc, ref, maxsep=COARSE_MAXSEP, binarc=COARSE_BIN):
@@ -359,14 +365,34 @@ def _solve(byve, byv, coarse, c_ra, c_dec, ref, prop, field, filt, modlabel=None
         c_ra_legacy = float(np.median(coarse[vis][0])); c_dec_legacy = float(np.median(coarse[vis][1]))
         consensus = build_consensus(byv[vis])
         cc_ra = consensus.ra.deg + c_ra / 3600.0; cc_dec = consensus.dec.deg + c_dec / 3600.0
+        # PER-VISIT coarse residual on top of the shared per-filter i2d seed.  REQUIRED:
+        # visits can carry very different raw guide-star pointing errors (brick-1182
+        # visit001 ~22" vs visit002 ~2").  The single mosaic-wide i2d coarse captures only
+        # the dominant visit, so the other visit is left mis-seeded and the <SEARCH fine NN
+        # below cannot bridge it -> it silently inherits the dominant visit's shift (the
+        # cause of the 2026-07 brick-1182 visit001 corruption: all visits got visit002's
+        # +1.9" instead of visit001's true -17.5").  A per-visit large-radius histogram
+        # xcorr (crowding-proof) recovers each visit's own bulk before the fine step.
+        cv_ra, cv_dec = c_ra, c_dec
+        vx = coarse_xcorr(SkyCoord(cc_ra * u.deg, cc_dec * u.deg), ref, maxsep=COARSE_MAXSEP_VISIT)
+        if vx[0] is not None:
+            vratio = vx[3] / vx[4] if vx[4] > 0 else np.inf
+            # only apply a MEANINGFUL per-visit correction (> the fine-NN radius); small
+            # residuals are left to the fine step to avoid double counting.
+            if vratio >= COARSE_MIN_PEAK_RATIO and np.hypot(vx[0], vx[1]) > SEARCH.to(u.arcsec).value:
+                cc_ra = cc_ra + vx[0] / 3600.0; cc_dec = cc_dec + vx[1] / 3600.0
+                cv_ra = c_ra + vx[0]; cv_dec = c_dec + vx[1]
+                print(f"  {tag}visit{vis}: PER-VISIT coarse ADD ({vx[0]:+.3f},{vx[1]:+.3f})\" "
+                      f"peak/bg={vratio:.1f} npairs={vx[2]}  (visit differs from mosaic seed)",
+                      flush=True)
         res = coord_shift(cc_ra, cc_dec, ref)
         if res is None:
             # coarse alone (no per-visit fine refinement available)
             res = (0.0, 0.0, 0.0, 0.0, 0)
-            print(f"  visit{vis}: fine tie weak; using i2d coarse alone")
-        bulk_ra = c_ra + res[0]; bulk_dec = c_dec + res[1]
+            print(f"  visit{vis}: fine tie weak; using coarse alone")
+        bulk_ra = cv_ra + res[0]; bulk_dec = cv_dec + res[1]
         print(f"  {tag}visit{vis}: i2d_coarse({c_ra:+.4f},{c_dec:+.4f})\" [legacy {c_ra_legacy:+.4f},"
-              f"{c_dec_legacy:+.4f}] + fine({res[0]*1000:+.1f},{res[1]*1000:+.1f})mas "
+              f"{c_dec_legacy:+.4f}] pervisit({cv_ra:+.4f},{cv_dec:+.4f}) + fine({res[0]*1000:+.1f},{res[1]*1000:+.1f})mas "
               f"=> BULK ({bulk_ra:.4f},{bulk_dec:.4f})\" SEM {res[2]:.2f}/{res[3]:.2f}mas "
               f"n={res[4]}; consensus={len(consensus)}", flush=True)
         for exp in sorted(e for (v, e) in byve if v == vis):

--- a/brick2221/analysis/relock_exposures.py
+++ b/brick2221/analysis/relock_exposures.py
@@ -58,18 +58,44 @@ def virac2(epoch):
     return SkyCoord((ra + (pr * dt / 3.6e6) / np.cos(np.radians(dec))) * u.deg, (dec + pd * dt / 3.6e6) * u.deg)
 
 
-def robust_shift(sc, ref, search=0.3 * u.arcsec, clip=60.):
-    """one rigid (dRA,dDec) mas to add to sc to land on ref (ref-sc), clipped median."""
-    idx, sep, _ = sc.match_to_catalog_sky(ref)
+def robust_shift(sc, ref, search=0.3 * u.arcsec, clip=60.,
+                 coarse_maxsep=25. * u.arcsec, coarse_bin=0.08, min_peak_ratio=5.0):
+    """one rigid (dRA_cosd, dDec) mas to add to sc to land on ref (ref-sc), clipped median.
+
+    FIRST bridge any large per-visit guide-star offset with a crowding-proof
+    offset-HISTOGRAM stack (all pairs within ``coarse_maxsep``, take the 2-D peak).
+    A plain nearest-neighbour median within ``search`` CANNOT see past its own
+    radius: brick-1182 visit1 is ~17.5" off, so a 0.3" NN silently returns
+    too-few/~0 and the whole visit is dropped or mis-locked (the 2026-07 visit001
+    corruption).  Histogram stacking is crowding-immune and recovers the true
+    offset up to ``coarse_maxsep`` before the fine NN refines the residual."""
+    from astropy.coordinates import search_around_sky
+    cra = cdec = 0.0   # coarse coordinate offset (arcsec, NO cosd) to add to sc
+    ia, ib, _, _ = search_around_sky(sc, ref, coarse_maxsep)
+    if len(ia) >= 50:
+        dra_a = (ref[ib].ra - sc[ia].ra).to(u.arcsec).value
+        ddec_a = (ref[ib].dec - sc[ia].dec).to(u.arcsec).value
+        mm = coarse_maxsep.to(u.arcsec).value
+        bins = np.arange(-mm, mm + coarse_bin, coarse_bin)
+        H, xe, ye = np.histogram2d(dra_a, ddec_a, bins=[bins, bins])
+        i, j = np.unravel_index(H.argmax(), H.shape)
+        bg = float(np.median(H[H > 0])) if (H > 0).any() else 0.0
+        if bg > 0 and H.max() / bg >= min_peak_ratio:
+            cra = (xe[i] + xe[i + 1]) / 2.0; cdec = (ye[j] + ye[j + 1]) / 2.0
+    cosd = np.cos(np.radians(-28.70))
+    sc2 = SkyCoord((sc.ra.deg + cra / 3600.0) * u.deg, (sc.dec.deg + cdec / 3600.0) * u.deg)
+    idx, sep, _ = sc2.match_to_catalog_sky(ref)
     m = sep < search
     if m.sum() < 30:
         return None, None, int(m.sum())
-    a = sc[m]; b = ref[idx[m]]
+    a = sc2[m]; b = ref[idx[m]]
     dra = ((b.ra - a.ra) * np.cos(a.dec.radian)).to(u.mas).value
     ddec = (b.dec - a.dec).to(u.mas).value
     md, mdd = np.median(dra), np.median(ddec)
     cl = np.hypot(dra - md, ddec - mdd) < clip
-    return float(np.median(dra[cl])), float(np.median(ddec[cl])), int(cl.sum())
+    # total = coarse bridge (converted to cosd mas) + fine residual (already cosd mas)
+    return (float(cra * cosd * 1000.0 + np.median(dra[cl])),
+            float(cdec * 1000.0 + np.median(ddec[cl])), int(cl.sum()))
 
 
 def lock_filter(filt):


### PR DESCRIPTION
Fixes the VIRAC2 locked-offsets builders that collapsed all visits of a filter onto the **dominant visit's** shift when visits have very different raw guide-star pointing errors.

**Impact:** brick-1182 visit001 is ~22" off (−17.5"/+13.5"), visit002 ~2". Both got visit002's +1.9", so `fix_alignment` mis-corrected every visit001 exposure by ~19–23" → the **top half of every 1182 mosaic + catalog was untied to VIRAC2** (bottom half fine). Confirmed by per-tile histogram-contrast (bottom ~30×, top ~2×).

**`build_virac2_locked_perexp.py`:** the per-FILTER coarse tie was measured once on the full `merged_i2d` (dominant visit) and applied to every visit as the seed; the `<SEARCH`=0.3" fine NN then could not bridge the other visit's large residual, so it inherited the dominant shift. Add a **per-visit** large-radius histogram xcorr (`COARSE_MAXSEP_VISIT=25"`, crowding-proof, peak/bg-gated) on each visit's consensus before the fine step.

**`relock_exposures.py`:** `robust_shift` used a plain 0.3" NN median — cannot see a 17.5" offset (visit001 dropped/mislocked). Prepend the same 25" offset-histogram bridge before the fine NN.

Histogram stacking is crowding-immune and recovers offsets up to its radius, unlike NN-median. `COARSE_MAXSEP` must exceed the largest raw per-visit pointing error (~22"), not the ~2" previously assumed.

Note: the production `Offsets_JWST_Brick1182_VIRAC2locked.csv` was already hand-corrected (visit001 → −17.5"/+13.5", validated: VIRAC2 contrast 1.7→19.4); this fixes the builder so a rebuild reproduces it instead of re-corrupting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)