### PR TITLE
Astrometry + proper-motion analysis tools for the Brick

### DIFF
--- a/brick2221/analysis/brick_match_quality_review.py
+++ b/brick2221/analysis/brick_match_quality_review.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""Astrometric matching-quality review for the Brick, using the ROBUST
+offset-histogram (2D mode) method, NOT nearest-neighbour mean/median.
+
+Why: in a confusion-limited field, NN matching pairs many sources to a random
+neighbour.  True matches pile up at the real systematic offset; mispairs form a
+broad ~uniform background.  The 2D MODE of the offset distribution recovers the
+systematic offset robustly; the mean/median is pulled by the mispair background.
+For each pair we report the mode, the concentration (fraction of matches within
+20 mas of the mode = reliability), the core scatter (MAD near the mode = the
+per-star matching floor), AND the naive NN-median for contrast.
+"""
+import numpy as np
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+import os, warnings; warnings.filterwarnings('ignore')
+
+C = '/orange/adamginsburg/jwst/brick/catalogs/'
+VIRAC = '/orange/adamginsburg/jwst/brick/astrometry_retie_qualcuts_20251211/refcache/virac2.fits'
+DT = 8.70
+
+def load_jwst(band):
+    t = Table.read(C + f'{band}_merged_indivexp_merged_resbgsub_m7_dao_basic_vetted.fits')
+    sc = t['skycoord']
+    ok = np.isfinite(sc.ra.deg) & np.isfinite(sc.dec.deg)
+    return SkyCoord(sc.ra.deg[ok]*u.deg, sc.dec.deg[ok]*u.deg)
+
+def load_virac():
+    v = Table.read(VIRAC)
+    ra = np.asarray(v['RAJ2000'], float); de = np.asarray(v['DEJ2000'], float)
+    pmra = np.nan_to_num(np.asarray(v['pmRA'], float)); pmde = np.nan_to_num(np.asarray(v['pmDE'], float))
+    cosd = np.cos(np.radians(de))
+    return SkyCoord((ra + pmra*DT/3.6e6/cosd)*u.deg, (de + pmde*DT/3.6e6)*u.deg)
+
+def offset_mode(A, B, radius=0.5, half=100, binsz=3.0):
+    """NN match A->B within radius(arcsec); 2D-mode of (dRA_onsky, dDec) in mas."""
+    idx, sep, _ = A.match_to_catalog_sky(B)
+    m = sep < radius*u.arcsec
+    dra = (A.ra.deg[m] - B.ra.deg[idx[m]])*np.cos(np.radians(A.dec.deg[m]))*3.6e6
+    dde = (A.dec.deg[m] - B.dec.deg[idx[m]])*3.6e6
+    edges = np.arange(-half, half+binsz, binsz)
+    H, xe, ye = np.histogram2d(dra, dde, bins=[edges, edges])
+    iy, ix = np.unravel_index(np.argmax(H.T), H.T.shape)  # peak bin
+    px = 0.5*(xe[ix]+xe[ix+1]); py = 0.5*(ye[iy]+ye[iy+1])
+    # refine mode: flux-weighted centroid in a 15 mas window
+    w = (np.abs(dra-px) < 15) & (np.abs(dde-py) < 15)
+    if w.sum() > 5:
+        px, py = np.mean(dra[w]), np.mean(dde[w])
+    near = np.hypot(dra-px, dde-py) < 20
+    conc = near.sum()/m.sum() if m.sum() else 0
+    core = np.hypot(dra-px, dde-py)[near]
+    mad = np.median(np.abs(core - np.median(core))) if near.sum() else np.nan
+    return dict(n=int(m.sum()), mode=(px, py), conc=conc, coremad=mad,
+                nnmed=(np.median(dra), np.median(dde)))
+
+print('Loading catalogs...')
+cat = {b: load_jwst(b) for b in ['f115w', 'f200w', 'f356w', 'f444w', 'f212n', 'f182m']}
+vir = load_virac()
+print(f'  sizes: ' + ', '.join(f'{k}={len(v):,}' for k, v in cat.items()) + f', virac={len(vir):,}\n')
+
+PAIRS = [
+    ('JWST<->VIRAC   F115W vs VIRAC2', cat['f115w'], vir),
+    ('JWST<->VIRAC   F200W vs VIRAC2', cat['f200w'], vir),
+    ('JWST<->VIRAC   F212N vs VIRAC2', cat['f212n'], vir),
+    ('same-obs 1182  F115W vs F200W ', cat['f115w'], cat['f200w']),
+    ('same-obs 1182  F200W vs F356W ', cat['f200w'], cat['f356w']),
+    ('same-obs 2221  F182M vs F212N ', cat['f182m'], cat['f212n']),
+    ('CROSS-OBS      F200W vs F212N ', cat['f200w'], cat['f212n']),  # the cross-tie pair
+    ('CROSS-OBS      F115W vs F212N ', cat['f115w'], cat['f212n']),
+    ('CROSS-OBS      F444W vs F466N ', cat['f444w'], vir),           # placeholder guard below
+]
+print(f'{"pair":32s} {"N":>7} {"mode(dRA,dDec) mas":>20} {"conc":>6} {"coreMAD":>8} {"NNmedian":>18}')
+for name, A, B in PAIRS[:-1]:
+    r = offset_mode(A, B)
+    print(f'{name:32s} {r["n"]:7d} ({r["mode"][0]:+6.1f},{r["mode"][1]:+6.1f})     '
+          f'{r["conc"]*100:5.0f}% {r["coremad"]:7.1f}  ({r["nnmed"][0]:+6.1f},{r["nnmed"][1]:+6.1f})')
+
+# ---- F115W inter-module proxy: N-S offset-mode split vs VIRAC2 ----------------
+print('\nF115W spatial-half offset-mode vs VIRAC2 (proxy for module structure):')
+A = cat['f115w']
+for lab, sub in [('South half', A[A.dec.deg < -28.712]), ('North half', A[A.dec.deg > -28.712])]:
+    r = offset_mode(sub, vir)
+    print(f'  {lab}: N={r["n"]:6d}  mode=({r["mode"][0]:+6.1f},{r["mode"][1]:+6.1f}) mas  conc={r["conc"]*100:.0f}%')

--- a/brick2221/analysis/f200w_virac_mag_astrom_test.py
+++ b/brick2221/analysis/f200w_virac_mag_astrom_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+"""Is F200W astrometry really arcsec-off from VIRAC2?  Diagnostic: match VIRAC to
+F200W, look at the SEPARATION distribution, the magnitude agreement, and whether
+flux-vetting (keep the F200W_AB-Ks ridge) removes exactly the arcsec 'matches'.
+
+Punchline hypothesis: the arcsec offsets are NON-COUNTERPARTS (VIRAC sources with
+no F200W detection in the 1182 footprint, paired to a random neighbour), NOT an
+F200W astrometry error.  Real counterparts sit at ~tens of mas.
+"""
+import numpy as np
+import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+import warnings; warnings.filterwarnings('ignore')
+
+snap = Table.read('/blue/adamginsburg/adamginsburg/jwst/brick/astrometry_diag/m8_dedup_1182_snapshot_20260708.fits')
+sc = snap['skycoord_f200w']; mab = np.asarray(snap['mag_ab_f200w'], float)
+fj = np.asarray(snap['flux_jy_f200w'], float); efj = np.asarray(snap['eflux_jy_f200w'], float)
+ok = np.isfinite(sc.ra.deg) & np.isfinite(mab) & np.isfinite(fj) & (fj > 0) & (efj > 0) & (fj/efj > 5)
+jsc = SkyCoord(sc.ra.deg[ok]*u.deg, sc.dec.deg[ok]*u.deg); mab = mab[ok]
+
+v = Table.read('/orange/adamginsburg/jwst/brick/astrometry_retie_qualcuts_20251211/refcache/virac2.fits')
+vra = np.asarray(v['RAJ2000'], float); vde = np.asarray(v['DEJ2000'], float)
+pmra = np.nan_to_num(np.asarray(v['pmRA'], float)); pmde = np.nan_to_num(np.asarray(v['pmDE'], float))
+Ks = np.asarray(v['Ksmag'], float); cosd = np.cos(np.radians(vde))
+vsc = SkyCoord((vra + pmra*8.7/3.6e6/cosd)*u.deg, (vde + pmde*8.7/3.6e6)*u.deg)
+
+idx, sep, _ = vsc.match_to_catalog_sky(jsc)     # VIRAC -> nearest F200W, NO cut
+sa = sep.arcsec
+color = mab[idx] - Ks                            # F200W_AB - Ks (near reddening-free)
+RIDGE = 2.15
+onridge = np.abs(color - RIDGE) < 0.75           # flux-vet
+close = sa < 0.3
+
+# on-sky offsets for the candidate-counterpart set
+dra = (vsc.ra.deg - jsc.ra.deg[idx])*np.cos(np.radians(vde))*3.6e6
+dde = (vsc.dec.deg - jsc.dec.deg[idx])*3.6e6
+
+def mode2d(x, y, half=120, b=3):
+    e = np.arange(-half, half+b, b); H, xe, ye = np.histogram2d(x, y, bins=[e, e])
+    iy, ix = np.unravel_index(np.argmax(H.T), H.T.shape)
+    px, py = 0.5*(xe[ix]+xe[ix+1]), 0.5*(ye[iy]+ye[iy+1])
+    w = (np.abs(x-px) < 15) & (np.abs(y-py) < 15)
+    if w.sum() > 5: px, py = x[w].mean(), y[w].mean()
+    return px, py
+
+print('=== SEPARATION percentiles (VIRAC->F200W nearest) ===')
+for lab, s in [('all', np.ones(len(sa), bool)), ('flux-vetted (on-ridge)', onridge)]:
+    q = np.percentile(sa[s], [25, 50, 75, 90])*1000
+    print(f'  {lab:24s} N={s.sum():6d}  p25/50/75/90 = {q[0]:6.0f}/{q[1]:6.0f}/{q[2]:7.0f}/{q[3]:7.0f} mas  frac>1\"={np.mean(sa[s]>1):.2f}')
+# does flux-vet remove the arcsec 'matches'?
+arc = sa > 1.0
+print(f'\nOf arcsec (>1\") matches: on-ridge frac = {onridge[arc].mean():.2f}  (random color would give ~{ (np.abs(np.random.default_rng(0).uniform(-2,4,arc.sum())-RIDGE)<0.75).mean():.2f})')
+print(f'Of close (<0.15\") matches: on-ridge frac = {onridge[sa<0.15].mean():.2f}')
+tight = onridge & close
+px, py = mode2d(dra[tight], dde[tight])
+core = np.hypot(dra[tight]-px, dde[tight]-py)
+print(f'\nflux-vetted+close F200W<->VIRAC: N={tight.sum()}  offset MODE=({px:+.1f},{py:+.1f}) mas  '
+      f'coreMAD={np.median(np.abs(core[core<30]-np.median(core[core<30]))):.1f} mas  median|sep|={np.median(sa[tight])*1000:.0f} mas')
+
+# ---- figure ------------------------------------------------------------------
+fig = plt.figure(figsize=(15, 9))
+ax = fig.add_subplot(2, 3, 1)
+ax.hist(np.log10(sa*1000), bins=80, color='gray', alpha=0.6, label='all NN')
+ax.hist(np.log10(sa[onridge]*1000), bins=80, color='C2', alpha=0.7, label='flux-vetted')
+for xv in [np.log10(x) for x in (100, 1000)]: ax.axvline(xv, color='k', ls=':', lw=0.6)
+ax.set_xlabel('log10 separation (mas)'); ax.set_ylabel('N'); ax.legend(fontsize=8)
+ax.set_title('VIRAC->F200W separation\n(dotted: 0.1", 1")')
+
+ax = fig.add_subplot(2, 3, 2)
+ax.scatter(Ks[close], mab[idx[close]], s=3, alpha=0.2)
+xx = np.linspace(10, 18, 10); ax.plot(xx, xx+RIDGE, 'r-', label=f'Ks+{RIDGE}')
+ax.set_xlabel('VIRAC Ks'); ax.set_ylabel('F200W AB'); ax.legend(fontsize=8)
+ax.set_title(f'mag agreement (<0.3" matches)\nmedian F200W_AB-Ks={np.median(color[close]):.2f}')
+
+ax = fig.add_subplot(2, 3, 3)
+ax.scatter(sa[sa < 1.5]*1000, color[sa < 1.5], s=2, alpha=0.15)
+ax.axhline(RIDGE, color='r'); ax.axhspan(RIDGE-0.75, RIDGE+0.75, color='r', alpha=0.12)
+ax.set_xlabel('separation (mas)'); ax.set_ylabel('F200W_AB - Ks'); ax.set_xlim(0, 1500); ax.set_ylim(-1, 6)
+ax.set_title('color vs separation\n(on-ridge stars are the close ones)')
+
+ax = fig.add_subplot(2, 3, 4)
+ax.hexbin(dra[tight], dde[tight], gridsize=40, extent=[-60, 60, -60, 60], cmap='viridis', mincnt=1)
+ax.plot(px, py, 'r+', ms=14, mew=2); ax.set_aspect('equal')
+ax.set_xlabel('dRA (mas)'); ax.set_ylabel('dDec (mas)')
+ax.set_title(f'offset VPD (flux-vetted+close)\nmode ({px:+.0f},{py:+.0f}) mas')
+
+ax = fig.add_subplot(2, 3, 5)
+q = ax.scatter(jsc.ra.deg[idx[tight]], jsc.dec.deg[idx[tight]], c=np.hypot(dra[tight]-px, dde[tight]-py),
+               s=4, cmap='plasma', vmax=30)
+ax.invert_xaxis(); ax.set_aspect('equal', adjustable='datalim')
+ax.set_xlabel('RA'); ax.set_ylabel('Dec'); fig.colorbar(q, ax=ax, label='|offset-mode| mas', shrink=0.8)
+ax.set_title('spatial map of residual (uniform = no local arcsec error)')
+
+ax = fig.add_subplot(2, 3, 6); ax.axis('off')
+txt = ('VERDICT\n'
+       f'real counterparts (flux-vetted+<0.3"): {tight.sum()}\n'
+       f'  systematic offset mode: ({px:+.0f},{py:+.0f}) mas\n'
+       f'  core scatter: ~{np.median(np.abs(core[core<30]-np.median(core[core<30]))):.0f} mas (VIRAC floor)\n\n'
+       f'arcsec ">1\"" matches: {int((sa>1).sum())} ({100*np.mean(sa>1):.0f}%)\n'
+       f'  on-ridge frac of those: {onridge[arc].mean():.2f}\n'
+       f'  -> flux-vet REMOVES them = they are\n'
+       f'     NON-COUNTERPARTS (no F200W in footprint),\n'
+       f'     NOT an F200W astrometry error\n\n'
+       'F200W-VIRAC is ~tens of mas, NOT arcsec.\n'
+       'Arcsec reports = unvetted NN to sources\n'
+       'with no real counterpart, OR sampling the\n'
+       '1182 i2d MOSAIC (had ~2" WCS err) not the\n'
+       'CATALOG.')
+ax.text(0.02, 0.98, txt, va='top', fontsize=9, family='monospace')
+fig.suptitle('F200W <-> VIRAC2: magnitude agreement + astrometry (is it really arcsec-off?)', fontsize=12)
+fig.tight_layout()
+out = '/orange/adamginsburg/jwst/brick/astrometry_diag/f200w_virac_mag_astrom_test.png'
+fig.savefig(out, dpi=130, bbox_inches='tight'); print('\nwrote', out)

--- a/brick2221/analysis/i2d_offset_audit.py
+++ b/brick2221/analysis/i2d_offset_audit.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Measure each 1182 i2d mosaic's WCS offset vs the (correct) catalog, by
+projecting bright catalog stars into the mosaic and centroiding them.  A correct
+i2d puts each star at its predicted pixel (offset ~0); a misaligned i2d shows a
+systematic centroid offset = the mosaic WCS error.
+"""
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+from astropy.nddata import Cutout2D
+import warnings, os; warnings.filterwarnings('ignore')
+
+snap = Table.read('/blue/adamginsburg/adamginsburg/jwst/brick/astrometry_diag/m8_dedup_1182_snapshot_20260708.fits')
+
+def bright_stars(band, nmax=800):
+    sc = snap[f'skycoord_{band}']; f = np.asarray(snap[f'flux_jy_{band}'], float)
+    ef = np.asarray(snap[f'eflux_jy_{band}'], float)
+    q = np.asarray(snap[f'qfit_{band}'], float) if f'qfit_{band}' in snap.colnames else np.zeros(len(snap))
+    ok = np.isfinite(sc.ra.deg) & np.isfinite(f) & (f > 0) & (ef > 0) & (f/ef > 30) & (q < 0.1)
+    idx = np.argsort(f[ok])[::-1][:nmax*3]
+    return SkyCoord(sc.ra.deg[ok][idx]*u.deg, sc.dec.deg[ok][idx]*u.deg), f[ok][idx]
+
+def measure(path, sc, box=9):
+    h = fits.open(path, memmap=True)
+    ext = 1 if h[0].data is None else 0
+    if len(h) > 1 and h[1].name == 'SCI': ext = 1
+    data = h[ext].data; w = WCS(h[ext].header)
+    scale = np.sqrt(np.abs(np.linalg.det(w.pixel_scale_matrix)))*3600*1000  # mas/pix
+    px, py = w.world_to_pixel(sc)
+    offx, offy = [], []
+    ny, nx = data.shape
+    for x0, y0 in zip(px, py):
+        if not (box < x0 < nx-box and box < y0 < ny-box): continue
+        xi, yi = int(round(x0)), int(round(y0))
+        cut = data[yi-box:yi+box+1, xi-box:xi+box+1].astype(float)
+        if not np.isfinite(cut).all() or cut.max() <= 0: continue
+        cut = cut - np.median(cut); cut[cut < 0] = 0
+        if cut.sum() <= 0: continue
+        yy, xx = np.mgrid[0:2*box+1, 0:2*box+1]
+        cx = (cut*xx).sum()/cut.sum(); cy = (cut*yy).sum()/cut.sum()
+        # centroid vs the sub-pixel predicted position
+        offx.append((xi-box+cx) - x0); offy.append((yi-box+cy) - y0)
+        if len(offx) >= 600: break
+    offx = np.array(offx); offy = np.array(offy)
+    # robust: median, in mas (pixel offset * scale); note pixel x = -RA roughly
+    return len(offx), np.median(offx)*scale, np.median(offy)*scale, scale
+
+BASE = '/orange/adamginsburg/jwst/brick'
+for band in ['f200w', 'f356w', 'f115w', 'f444w']:
+    sc, _ = bright_stars(band)
+    print(f'\n=== {band.upper()} (N bright cat stars={len(sc)}) ===')
+    B = band; P = f'{BASE}/{B.upper()}/pipeline/jw01182-o004_t001_nircam_clear-{B}'
+    for tag in ['-merged_i2d', '-merged_data_i2d', '-merged-reproject_i2d', '-nrcb_i2d', '-nrca_i2d']:
+        path = P + tag + '.fits'
+        if not os.path.exists(path): continue
+        n, ox, oy, sc_mas = measure(path, sc)
+        mag = np.hypot(ox, oy)
+        flag = '  <-- ARCSEC' if mag > 500 else ('  <- off' if mag > 60 else '')
+        mt = __import__('time').ctime(os.path.getmtime(path))[4:16]
+        print(f'  {tag:24s} n={n:4d} scale={sc_mas:.1f}mas  centroid-offset=({ox:+7.1f},{oy:+7.1f}) mas |{mag:6.1f}| {mt}{flag}')

--- a/brick2221/analysis/pm_discrepancy_binaries.py
+++ b/brick2221/analysis/pm_discrepancy_binaries.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+"""Sources where the VIRAC catalog PM and the JWST-VIRAC PM disagree most, and a
+test of whether the disagreement is a VVV blend/binary.
+
+Two independent PM estimates per star:
+  PM_VIRAC       = (pmRA, pmDE) from the VIRAC2 catalog (VVV-internal, ~2010-2015)
+  PM_JWST-VIRAC  = (JWST_F200W_pos@2022.70 - VIRAC_pos@2014.0) / 8.70 yr
+Discrepancy = |PM_JWST-VIRAC - PM_VIRAC|.  A VVV blend corrupts the VIRAC centroid
+-> spurious PM_VIRAC; JWST resolves the pair.  So rank by discrepancy, flag
+multiplicity (>=2 JWST F200W sources within one VVV PSF), and cut out both surveys.
+"""
+import os
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from astropy.table import Table
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.coordinates import SkyCoord
+from astropy.nddata import Cutout2D
+from astropy import units as u
+
+BASE = '/orange/adamginsburg/jwst/brick'
+OUTDIR = f'{BASE}/astrometry_diag/pm_binaries'
+os.makedirs(OUTDIR, exist_ok=True)
+
+VIRAC_EPOCH = 2014.0
+JWST_EPOCH = 2022.70
+DT = JWST_EPOCH - VIRAC_EPOCH          # 8.70 yr
+VVV_PSF = 0.9                          # arcsec, VVV seeing scale for blend test
+
+SNAP = f'{BASE}/astrometry_diag/m8_dedup_1182_snapshot_20260708.fits'
+VIRAC = f'{BASE}/astrometry_retie_qualcuts_20251211/refcache/virac2.fits'
+VVV = '/orange/adamginsburg/jwst/vvv/vvv_dr4_Hband_GC_mosaic_0p25.fits'
+F200 = f'{BASE}/F200W/pipeline/jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits'
+
+# ---- JWST F200W sources ------------------------------------------------------
+snap = Table.read(SNAP)
+scj = snap['skycoord_f200w']
+fj = np.asarray(snap['flux_jy_f200w'], float)
+efj = np.asarray(snap['eflux_jy_f200w'], float)
+ra_j, dec_j = scj.ra.deg, scj.dec.deg
+okj = np.isfinite(ra_j) & np.isfinite(dec_j) & np.isfinite(fj) & (fj > 0) & np.isfinite(efj) & (efj > 0)
+j = SkyCoord(ra_j[okj]*u.deg, dec_j[okj]*u.deg)
+fj_ok = fj[okj]; snr_ok = fj_ok/efj[okj]
+mag_f200_ab = -2.5*np.log10(fj_ok/3631.0)
+print(f'JWST F200W usable: {okj.sum():,}')
+
+# ---- VIRAC2 native 2014, propagate to JWST epoch -----------------------------
+vt = Table.read(VIRAC)
+vra = np.asarray(vt['RAJ2000'], float); vde = np.asarray(vt['DEJ2000'], float)
+pmRA = np.asarray(vt['pmRA'], float); pmDE = np.asarray(vt['pmDE'], float)   # mas/yr, pmRA=mu_a*cosd
+epmRA = np.asarray(vt['e_pmRA'], float); epmDE = np.asarray(vt['e_pmDE'], float)
+Ks = np.asarray(vt['Ksmag'], float)
+cosd = np.cos(np.radians(vde))
+vra_p = vra + (pmRA/cosd)*DT/3.6e6       # deg
+vde_p = vde + pmDE*DT/3.6e6
+okv = np.isfinite(vra_p) & np.isfinite(vde_p) & np.isfinite(pmRA) & np.isfinite(pmDE)
+vp = SkyCoord(vra_p[okv]*u.deg, vde_p[okv]*u.deg)       # VIRAC propagated to 2022.70
+v2014 = SkyCoord(vra[okv]*u.deg, vde[okv]*u.deg)
+pmRA, pmDE, epmRA, epmDE, Ks = pmRA[okv], pmDE[okv], epmRA[okv], epmDE[okv], Ks[okv]
+print(f'VIRAC2 with PM: {okv.sum():,}')
+
+# ---- match VIRAC(propagated) -> nearest JWST F200W ---------------------------
+idx, sep, _ = vp.match_to_catalog_sky(j)
+jm = j[idx]
+# JWST-VIRAC PM from native 2014 endpoint to matched JWST 2022.70 position
+dra_pm = (jm.ra.deg - vra[okv]) * cosd[okv] * 3.6e6 / DT     # mas/yr on-sky
+dde_pm = (jm.dec.deg - vde[okv]) * 3.6e6 / DT
+# frame tie: median over confident matches (tight, bright)
+tie_ok = (sep.arcsec < 0.12) & (snr_ok[idx] > 20)
+tie_ra = np.median(dra_pm[tie_ok] - pmRA[tie_ok])
+tie_de = np.median(dde_pm[tie_ok] - pmDE[tie_ok])
+print(f'frame tie (PM units): ({tie_ra:+.2f},{tie_de:+.2f}) mas/yr from {tie_ok.sum()} bright tight')
+disc_ra = (dra_pm - tie_ra) - pmRA
+disc_de = (dde_pm - tie_de) - pmDE
+disc = np.hypot(disc_ra, disc_de)              # mas/yr
+vpm = np.hypot(pmRA, pmDE)
+
+# ---- find CLEAN ISOLATED DOUBLES ---------------------------------------------
+# The Brick is confusion-limited: nearest-neighbour-in-a-crowd is meaningless.
+# A convincing "VVV binary" = exactly 2 comparable JWST F200W stars inside the VVV
+# beam and NOTHING else nearby, so VVV sees one blob and VIRAC centroids the pair.
+from astropy.coordinates import search_around_sky
+R_IN, R_OUT = 0.5, 1.0         # arcsec: pair radius, contamination radius
+vi, ji, d2d, _ = search_around_sky(vp, j, R_OUT*u.arcsec)   # vi->vp, ji->j
+sepas = d2d.arcsec
+from collections import defaultdict
+grp = defaultdict(list)
+for a, b, s in zip(vi, ji, sepas):
+    grp[a].append((s, b))
+
+snr_m = snr_ok[idx]
+cand_rows = []
+for a, lst in grp.items():
+    inr = sorted([(fj_ok[b], s, b) for s, b in lst if s < R_IN], reverse=True)  # bright->faint
+    if len(inr) < 2:                           # need a pair inside the VVV beam
+        continue
+    (f1, s1, b1), (f2, s2, b2) = inr[0], inr[1]
+    ratio = f1 / f2
+    if ratio > 3:                              # two brightest comparable
+        continue
+    if snr_ok[b1] < 15 or snr_ok[b2] < 15:
+        continue
+    # any OTHER source (in R_OUT) must be >=1.5 mag fainter than the 2nd -> negligible for the blob
+    others = [fl for fl, s, b in inr[2:]] + [fj_ok[b] for s, b in lst if R_IN <= s < R_OUT]
+    if others and max(others) > f2/4.0:        # a 3rd comparable source -> messy, skip
+        continue
+    compsep = j[b1].separation(j[b2]).arcsec
+    if not (0.12 < compsep < R_IN):
+        continue
+    # flux-weighted JWST centroid (what VVV/VIRAC would centroid on)
+    w = f1 + f2
+    cra = (j[b1].ra.deg*f1 + j[b2].ra.deg*f2)/w
+    cde = (j[b1].dec.deg*f1 + j[b2].dec.deg*f2)/w
+    jpmRA = (cra - vra[okv][a])*cosd[okv][a]*3.6e6/DT - tie_ra
+    jpmDE = (cde - vde[okv][a])*3.6e6/DT - tie_de
+    d = np.hypot(jpmRA - pmRA[a], jpmDE - pmDE[a])
+    cand_rows.append(dict(a=a, disc=d, compsep=compsep, ratio=ratio,
+                          jpmRA=jpmRA, jpmDE=jpmDE, b1=b1, b2=b2,
+                          f1=f1, f2=f2))
+print(f'\ndominant comparable pairs (2 bright in {R_IN}", ratio<3, no 3rd >f2/4 within '
+      f'{R_OUT}", both SNR>15): {len(cand_rows):,}')
+cand_rows.sort(key=lambda z: z['disc'], reverse=True)
+if not cand_rows:
+    import sys; print('no candidates -> nothing to plot'); sys.exit(0)
+
+topN = 12
+top = cand_rows[:topN]
+print('\n  #  disc  vpm  jwstpm  compsep ratio  Ks   f200_1 f200_2   RA         Dec')
+rows = []
+for r, cr in enumerate(top):
+    k = cr['a']; c = vp[k]
+    jpm = np.hypot(cr['jpmRA'], cr['jpmDE'])
+    m1 = -2.5*np.log10(cr['f1']/3631.); m2 = -2.5*np.log10(cr['f2']/3631.)
+    print(f'{r:3d} {cr["disc"]:5.1f} {vpm[k]:5.1f} {jpm:6.1f} {cr["compsep"]:6.2f} {cr["ratio"]:5.1f} '
+          f'{Ks[k]:5.1f} {m1:6.2f} {m2:6.2f}  {c.ra.deg:.6f} {c.dec.deg:.6f}')
+    rows.append(dict(ra=c.ra.deg, dec=c.dec.deg, ra2014=vra[okv][k], dec2014=vde[okv][k],
+                     disc=float(cr['disc']), vpm=float(vpm[k]), jwstpm=float(jpm),
+                     compsep=float(cr['compsep']), ratio=float(cr['ratio']), Ks=float(Ks[k]),
+                     f200w_ab_1=float(m1), f200w_ab_2=float(m2),
+                     pmRA=float(pmRA[k]), pmDE=float(pmDE[k]),
+                     jpmRA=float(cr['jpmRA']), jpmDE=float(cr['jpmDE'])))
+if rows:
+    Table(rows).write(f'{OUTDIR}/pm_discrepancy_top.fits', overwrite=True)
+
+# ---- cutouts -----------------------------------------------------------------
+vvv_h = fits.open(VVV, memmap=True); vvv_data = vvv_h[0].data; vvv_wcs = WCS(vvv_h[0].header)
+f2_h = fits.open(F200, memmap=True); f2_data = f2_h[1].data; f2_wcs = WCS(f2_h[1].header)
+CUT = 2.5*u.arcsec
+PMSCALE = 0.05                 # arcsec drawn per (mas/yr) for PM arrows
+
+nrow = len(top)
+fig, axes = plt.subplots(nrow, 2, figsize=(7.0, 3.4*max(nrow,1)), squeeze=False)
+for r, cr in enumerate(top):
+    k = cr['a']; c = vp[k]; c14 = v2014[k]
+    b1, b2 = cr['b1'], cr['b2']
+    for col, (data, wcs, name, pxsc) in enumerate(
+            [(vvv_data, vvv_wcs, 'VVV H (1.6um)', 0.25),
+             (f2_data, f2_wcs, 'JWST F200W (2.0um)', 0.031)]):
+        ax = axes[r][col]
+        try:
+            cut = Cutout2D(data, c, CUT, wcs=wcs)
+        except ValueError:
+            ax.text(0.5,0.5,'no coverage',ha='center',transform=ax.transAxes,fontsize=8)
+            ax.set_xticks([]); ax.set_yticks([]); continue
+        img = cut.data.astype(float); fin = np.isfinite(img) & (img != 0)
+        lo, hi = (np.nanpercentile(img[fin],[3,99.7]) if fin.sum()>10 else (np.nanmin(img),np.nanmax(img)))
+        ny, nx = img.shape
+        ax.imshow(img, origin='lower', cmap='gray', vmin=lo, vmax=hi)
+        ax.set_xlim(-0.5, nx-0.5); ax.set_ylim(-0.5, ny-0.5)   # lock to cutout
+        cw = cut.wcs
+        # VIRAC epochs
+        vx, vy = cw.world_to_pixel(c);   ax.plot(vx, vy, '+', color='cyan', ms=13, mew=1.8)
+        v14x, v14y = cw.world_to_pixel(c14); ax.plot(v14x, v14y, 'x', color='yellow', ms=8, mew=1.5)
+        # the two JWST pair components (red circles), other JWST dets (small orange)
+        near = j[j.separation(c) < 1.6*CUT]
+        for s in near:
+            sx, sy = cw.world_to_pixel(s)
+            ax.plot(sx, sy, 'o', mfc='none', mec='orange', ms=5, mew=0.8)
+        for b, lab in [(b1,'1'), (b2,'2')]:
+            sx, sy = cw.world_to_pixel(j[b])
+            ax.plot(sx, sy, 'o', mfc='none', mec='red', ms=9, mew=1.6)
+        # PM vectors from VIRAC@2022.7: VIRAC catalog (magenta), JWST-VIRAC (lime)
+        for (pra, pde, cl) in [(pmRA[k], pmDE[k], 'magenta'),
+                               (cr['jpmRA'], cr['jpmDE'], 'lime')]:
+            dxpix = -(pra*PMSCALE)/pxsc            # +RA = -x (E left)
+            dypix = (pde*PMSCALE)/pxsc
+            ax.arrow(vx, vy, dxpix, dypix, color=cl, width=0.2/pxsc*0.02,
+                     head_width=0.06/pxsc, length_includes_head=True, alpha=0.9)
+        ax.set_xticks([]); ax.set_yticks([]); ax.set_title(name, fontsize=8)
+        if col == 0:
+            ax.set_ylabel(f'#{r}  disc={cr["disc"]:.0f} mas/yr\nVIRACpm={vpm[k]:.0f}  sep={cr["compsep"]:.2f}"\n'
+                          f'Ks={Ks[k]:.1f}  rat={cr["ratio"]:.1f}', fontsize=7.5)
+fig.suptitle('PM-discrepancy blends (2.5" cutouts)\ncyan+ VIRAC@2022.7  yellow x VIRAC@2014  '
+             'red o = JWST pair  orange o = other JWST\nmagenta arrow = VIRAC catalog PM   lime arrow = JWST-VIRAC PM',
+             fontsize=9, y=1.001)
+fig.tight_layout()
+out = f'{OUTDIR}/pm_discrepancy_cutouts.png'
+fig.savefig(out, dpi=130, bbox_inches='tight')
+print('\nwrote', out)

--- a/brick2221/analysis/pm_jwst_virac_flystar.py
+++ b/brick2221/analysis/pm_jwst_virac_flystar.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+"""JWST(F200W, 2022.70) x VIRAC2(2014.0) proper motions via flystar, then an
+isolation filter for trustworthy PMs.  Compares the JW-VVV 2-epoch PM to the
+VIRAC-catalog (VVV-only) PM and counts how many stars each method delivers.
+
+Frame: VIRAC2/Gaia DR3.  JWST is affine-tied onto the VIRAC frame first
+(shift_to_virac_frame), then VIRAC->JWST counterparts are matched with VIRAC's
+own PM as a prior, and StarTable.fit_velocities fits the 2-epoch motion.
+"""
+import os, sys
+import numpy as np
+import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, search_around_sky
+from astropy import units as u
+sys.path.insert(0, '/blue/adamginsburg/adamginsburg/repos/jwst-gc-pipeline-wt-pm')
+from jwst_gc_pipeline.astrometry.multiepoch_pm import tangent_xy, shift_to_virac_frame
+from flystar.startables import StarTable
+
+BASE = '/orange/adamginsburg/jwst/brick'
+CAT = os.environ.get('JCAT', 'f200w')     # 'f200w' (1182 snapshot) or 'f212n' (2221 cross-tied)
+OUTDIR = f'{BASE}/astrometry_diag/pm_flystar'; os.makedirs(OUTDIR, exist_ok=True)
+EPOCH_V, EPOCH_J = 2014.0, 2022.70
+DT = EPOCH_J - EPOCH_V
+VVV_BEAM = 0.9          # arcsec: VVV seeing -> blend scale
+TAG = CAT
+
+SNAP = f'{BASE}/astrometry_diag/m8_dedup_1182_snapshot_20260708.fits'
+F212 = f'{BASE}/catalogs/f212n_merged_indivexp_merged_resbgsub_m7_dao_basic_vetted.fits'
+VIRAC = f'{BASE}/astrometry_retie_qualcuts_20251211/refcache/virac2.fits'
+
+# ---- JWST catalog (F200W deep 1182 pre-cross-tie, or F212N 2221 cross-tied) ---
+if CAT == 'f200w':
+    s = Table.read(SNAP); scj = s['skycoord_f200w']
+    fj = np.asarray(s['flux_jy_f200w'], float); efj = np.asarray(s['eflux_jy_f200w'], float)
+    ex = np.asarray(s['std_ra_f200w'], float); ey = np.asarray(s['std_dec_f200w'], float)
+    ok = (np.isfinite(scj.ra.deg) & np.isfinite(fj) & (fj > 0) & np.isfinite(efj) & (efj > 0) & (fj/efj > 5))
+    ra_j, dec_j = scj.ra.deg[ok], scj.dec.deg[ok]
+else:
+    s = Table.read(F212); scj = s['skycoord']
+    fj = np.asarray(s['flux'], float); efj = np.asarray(s['flux_err'], float)
+    ex = np.asarray(s['std_ra'], float); ey = np.asarray(s['std_dec'], float)
+    ok = (np.isfinite(scj.ra.deg) & np.isfinite(fj) & (fj > 0) & np.isfinite(efj) & (efj > 0) & (fj/efj > 5))
+    ra_j, dec_j = scj.ra.deg[ok], scj.dec.deg[ok]
+jflux = fj[ok]
+magj_instr = -2.5*np.log10(jflux)          # instrumental; zeropoint absorbed by color cal
+jwst = dict(sc=SkyCoord(ra_j*u.deg, dec_j*u.deg),
+            ex=np.where(np.isfinite(ex[ok])&(ex[ok]>0), ex[ok], 0.005),
+            ey=np.where(np.isfinite(ey[ok])&(ey[ok]>0), ey[ok], 0.005),
+            flux=jflux, mag_instr=magj_instr, epoch=EPOCH_J, n=int(ok.sum()))
+print(f'JWST {CAT.upper()} SNR>5: {jwst["n"]:,}')
+
+# ---- VIRAC2 ------------------------------------------------------------------
+vt = Table.read(VIRAC)
+vsc = SkyCoord(np.asarray(vt['RAJ2000'],float)*u.deg, np.asarray(vt['DEJ2000'],float)*u.deg)
+virac = dict(sc=vsc, mag=np.asarray(vt['Ksmag'],float),
+             ex=np.where(np.isfinite(np.asarray(vt['e_RAJ2000'],float)), np.asarray(vt['e_RAJ2000'],float)/1e3, 0.05),
+             ey=np.where(np.isfinite(np.asarray(vt['e_DEJ2000'],float)), np.asarray(vt['e_DEJ2000'],float)/1e3, 0.05),
+             pmra=np.asarray(vt['pmRA'],float), pmde=np.asarray(vt['pmDE'],float),
+             epmra=np.asarray(vt['e_pmRA'],float), epmde=np.asarray(vt['e_pmDE'],float),
+             epoch=EPOCH_V, n=len(vt))
+N_VVV_ONLY = int(np.isfinite(virac['pmra']).sum())
+print(f'VIRAC2 with catalog PM (VVV-only PMs): {N_VVV_ONLY:,}')
+
+# ---- CONSTANT-shift tie JWST onto VIRAC frame (preserve the PM field) --------
+# An affine tie would absorb the real bulk+gradient PM signal; the validated
+# approach removes only a constant bulk offset.  VIRAC propagated to JWST epoch:
+vra = virac['sc'].ra.deg + (np.nan_to_num(virac['pmra'])*DT/3.6e6)/np.cos(virac['sc'].dec.rad)
+vde = virac['sc'].dec.deg + (np.nan_to_num(virac['pmde'])*DT/3.6e6)
+vpred = SkyCoord(vra*u.deg, vde*u.deg)
+# pass 1: coarse bright match -> constant shift
+brightV = virac['mag'] < 14
+i0, s0, _ = vpred[brightV].match_to_catalog_sky(jwst['sc'])
+c0 = s0 < 0.5*u.arcsec
+dra0 = (jwst['sc'].ra.deg[i0][c0] - vpred[brightV].ra.deg[c0])*np.cos(np.radians(vpred[brightV].dec.deg[c0]))
+dde0 = (jwst['sc'].dec.deg[i0][c0] - vpred[brightV].dec.deg[c0])
+shift_ra, shift_de = np.median(dra0), np.median(dde0)   # deg (on-sky RA, dec)
+print(f'constant tie shift: ({shift_ra*3.6e6:+.1f},{shift_de*3.6e6:+.1f}) mas from {c0.sum()} bright')
+jwst['sc'] = SkyCoord((jwst['sc'].ra.deg - shift_ra/np.cos(jwst['sc'].dec.rad))*u.deg,
+                      (jwst['sc'].dec.deg - shift_de)*u.deg)
+
+# ---- match VIRAC(pm-propagated) -> JWST, mutual NN + FLUX VET -----------------
+idx, sep, _ = vpred.match_to_catalog_sky(jwst['sc'])
+idxb, _, _ = jwst['sc'].match_to_catalog_sky(vpred)
+mutual = idxb[idx] == np.arange(len(vpred))
+# flux vet: (JWST instr mag) - Ks forms a tight ridge; auto-calibrate the ridge
+# centre from bright tight pairs, keep within +/-0.75 mag -> rejects crowded mispairs
+color = jwst['mag_instr'][idx] - virac['mag']
+tight = (sep < 0.15*u.arcsec) & mutual & (virac['mag'] < 15) & np.isfinite(color)
+CO = np.median(color[tight])
+print(f'flux-vet ridge (JWST_instr - Ks) = {CO:.2f} from {tight.sum()} bright tight')
+fluxvet = np.abs(color - CO) < 0.75
+matched = (sep < 0.3*u.arcsec) & mutual & fluxvet
+print(f'VIRAC->JWST matched (mutual NN <0.3" + flux-vet): {matched.sum():,} '
+      f'(mutual<0.3" pre-vet: {((sep<0.3*u.arcsec)&mutual).sum():,})')
+
+# ---- 2-epoch StarTable + fit_velocities --------------------------------------
+center = SkyCoord(np.median(virac['sc'].ra), np.median(virac['sc'].dec))
+vx, vy = tangent_xy(virac['sc'], center)
+jx, jy = tangent_xy(jwst['sc'][idx], center)
+nref = virac['n']
+X = np.full((nref,2), np.nan); Y = np.full((nref,2), np.nan)
+XE = np.full((nref,2), np.nan); YE = np.full((nref,2), np.nan); Mg = np.full((nref,2), np.nan)
+X[:,0], Y[:,0], XE[:,0], YE[:,0], Mg[:,0] = vx, vy, virac['ex'], virac['ey'], virac['mag']
+X[matched,1] = jx[matched]; Y[matched,1] = jy[matched]
+XE[matched,1] = jwst['ex'][idx][matched]; YE[matched,1] = jwst['ey'][idx][matched]
+Mg[matched,1] = (jwst['mag_instr'][idx][matched] - CO)   # JWST on the Ks scale
+sel = matched.copy()
+name = np.array([f'v{i}' for i in np.where(sel)[0]])
+st = StarTable(name=name, x=X[sel], y=Y[sel], m=Mg[sel], xe=XE[sel], ye=YE[sel],
+               LIST_TIMES=[EPOCH_V, EPOCH_J], ref_list=0)
+st.fit_velocities(use_scipy=True, show_progress=False, mask_val=np.nan)
+
+pm = Table()
+pm['ra0'] = center.ra.deg + (st['x0']/3600.0)/np.cos(center.dec.rad)
+pm['dec0'] = center.dec.deg + (st['y0']/3600.0)
+pm['pm_ra'] = st['vx']*1e3; pm['pm_dec'] = st['vy']*1e3
+pm['pm_tot'] = np.hypot(pm['pm_ra'], pm['pm_dec'])
+selidx = np.where(sel)[0]
+# flystar 2-epoch velocity errors are degenerate (0 dof) -> analytic instead:
+# 2-epoch PM err = hypot(endpoint position errors)/baseline
+pm['pm_ra_err'] = np.hypot(virac['ex'][selidx], jwst['ex'][idx][selidx])*1e3/DT
+pm['pm_dec_err'] = np.hypot(virac['ey'][selidx], jwst['ey'][idx][selidx])*1e3/DT
+pm['virac_pmra'] = virac['pmra'][selidx]; pm['virac_pmde'] = virac['pmde'][selidx]
+pm['virac_pmtot'] = np.hypot(pm['virac_pmra'], pm['virac_pmde'])
+pm['virac_epmtot'] = np.hypot(virac['epmra'][selidx], virac['epmde'][selidx])
+pm['Ks'] = virac['mag'][selidx]
+
+# ---- isolation criteria (trustworthy) ----------------------------------------
+# The VVV/VIRAC 2014 centroid is a single dominant star iff no COMPARABLY BRIGHT
+# JWST source (flux > primary/DOMRATIO, ~1.5 mag) sits within the VVV beam; faint
+# companions do not move the VVV centroid.  Also require no other VIRAC star <1.0".
+# A clean VVV/VIRAC 2014 centroid needs the primary to dominate the beam by a wide
+# margin: a companion f_c at separation s shifts the VVV centroid by ~s*f_c/f_p, so
+# even a 1.5-mag companion (f/4) at 0.5" moves it ~60 mas (=7 mas/yr).  Require any
+# in-beam companion >2.5 mag fainter (f/10) AND no comparable star within 0.35".
+prim_jidx = idx[selidx]
+prim_flux = jwst['flux'][prim_jidx]
+vi, ji, d2d, _ = search_around_sky(vpred[sel], jwst['sc'], VVV_BEAM*u.arcsec)
+comp_flux = np.zeros(int(sel.sum()))            # brightest companion in beam
+comp_flux_close = np.zeros(int(sel.sum()))      # brightest companion within 0.35"
+for g, b, dd in zip(vi, ji, d2d.arcsec):
+    if b == prim_jidx[g]:
+        continue
+    if jwst['flux'][b] > comp_flux[g]:
+        comp_flux[g] = jwst['flux'][b]
+    if dd < 0.35 and jwst['flux'][b] > comp_flux_close[g]:
+        comp_flux_close[g] = jwst['flux'][b]
+frac = np.where(prim_flux > 0, comp_flux/prim_flux, np.nan)
+frac_close = np.where(prim_flux > 0, comp_flux_close/prim_flux, np.nan)
+vv_i, vv_j, vv_d, _ = search_around_sky(virac['sc'][sel], virac['sc'], 1.0*u.arcsec)
+n_virac_near = np.bincount(vv_i, minlength=sel.sum())
+good_err = np.isfinite(pm['pm_ra_err']) & (pm['pm_ra_err'] < 2) & (pm['pm_dec_err'] < 2)
+dominant = (frac < 0.10) & (frac_close < 0.25) & (n_virac_near == 1)
+trust = dominant & good_err
+pm['comp_flux_ratio'] = frac
+pm['n_virac_within_1arcsec'] = n_virac_near
+pm['dominant'] = dominant
+pm['trustworthy'] = trust
+pm.meta['epochs'] = [EPOCH_V, EPOCH_J]; pm.meta['frame'] = 'VIRAC2/Gaia DR3'
+pm.write(f'{OUTDIR}/pm_jwst_virac_{TAG}.fits', overwrite=True)
+
+# ---- counts + validation -----------------------------------------------------
+n_match = int(sel.sum()); n_trust = int(trust.sum())
+n_blended = int((frac >= 0.10).sum())
+print('\n==== PM YIELD ====')
+print(f'VVV-only PMs (VIRAC catalog):          {N_VVV_ONLY:,}')
+print(f'JW-VVV PMs (matched, flux-vetted):     {n_match:,}')
+print(f'JW-VVV PMs TRUSTWORTHY (isolated):     {n_trust:,}')
+print(f'  matched with comparable blend (frac>0.1 in VVV beam): {n_blended:,} '
+      f'({100*n_blended/n_match:.0f}%) -> VVV-only PM corrupted for these')
+
+def stats(a, b):
+    m = np.isfinite(a) & np.isfinite(b)
+    c = np.corrcoef(a[m], b[m])[0, 1]
+    slope = np.polyfit(a[m], b[m], 1)[0]
+    resid = b[m] - a[m]
+    mad = np.nanmedian(np.abs(resid - np.nanmedian(resid)))
+    return c, slope, mad, m.sum()
+print('\ntrustworthy JW-VVV vs VIRAC catalog PM:')
+for lab, jw, vc in [('pmRA', pm['pm_ra'], pm['virac_pmra']), ('pmDE', pm['pm_dec'], pm['virac_pmde'])]:
+    c, sl, mad, nn = stats(np.asarray(vc[trust]), np.asarray(jw[trust]))
+    print(f'  {lab}: corr={c:.2f} slope={sl:.2f} resid_mad={mad:.2f} mas/yr (n={nn})')
+t = pm[trust]
+
+# ---- plots -------------------------------------------------------------------
+fig, ax = plt.subplots(1, 3, figsize=(15, 4.6))
+for a,(x,y,lab) in zip(ax[:2], [(t['virac_pmra'],t['pm_ra'],'pmRA'),(t['virac_pmde'],t['pm_dec'],'pmDE')]):
+    a.plot(x,y,'.',ms=2,alpha=0.3)
+    lim=[-30,30]; a.plot(lim,lim,'r-',lw=1); a.set_xlim(lim); a.set_ylim(lim)
+    a.set_xlabel(f'VIRAC catalog {lab} (mas/yr)'); a.set_ylabel(f'JW-VVV {lab} (mas/yr)')
+    a.set_title(f'{lab}  (trustworthy, n={len(t)})'); a.set_aspect('equal')
+ax[2].bar(['VVV-only\n(VIRAC cat)','JW-VVV\nmatched','JW-VVV\ntrustworthy'],
+          [N_VVV_ONLY, n_match, n_trust], color=['gray','steelblue','seagreen'])
+ax[2].set_ylabel('N stars with a PM'); ax[2].set_title('PM yield')
+for i,v in enumerate([N_VVV_ONLY,n_match,n_trust]): ax[2].text(i,v,f'{v:,}',ha='center',va='bottom',fontsize=9)
+fig.tight_layout(); fig.savefig(f'{OUTDIR}/pm_yield_and_agreement_{TAG}.png', dpi=130, bbox_inches='tight')
+print('\nwrote', f'{OUTDIR}/pm_jwst_virac_{TAG}.fits', 'and pm_yield_and_agreement_{TAG}.png')

--- a/brick2221/analysis/pm_vpd_and_rescue.py
+++ b/brick2221/analysis/pm_vpd_and_rescue.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""(1) Quantify the PRECISION-RESCUE: VIRAC catalog PMs degrade steeply with
+faintness (e_pm median 2.9, ->6.7 at Ks 16-17), while the JW-VVV 2-epoch PM is
+limited by VIRAC's 2014 POSITION error (not its PM error), giving a ~1.8 mas/yr
+floor regardless.  So JW-VVV 'rescues' the many VIRAC stars whose own PM error
+is too large to use.  (2) VPD + bulk-subtracted PM map of the trustworthy set.
+"""
+import numpy as np
+import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt
+from astropy.table import Table
+
+OUT = '/orange/adamginsburg/jwst/brick/astrometry_diag/pm_flystar'
+pm = Table.read(f'{OUT}/pm_jwst_virac_f212n.fits')
+tr = pm[pm['trustworthy']]
+JW_FLOOR = 1.8            # empirical JW-VVV resid_mad vs VIRAC (mas/yr), F212N frame
+
+epm = np.asarray(tr['virac_epmtot'], float)     # VIRAC catalog PM uncertainty
+n = len(tr)
+print(f'trustworthy JW-VVV PMs: {n}')
+# JW-VVV precision (empirical floor) beats VIRAC when VIRAC e_pm > floor
+rescued = epm > JW_FLOOR
+strong = epm > 3.0                              # VIRAC PM effectively unusable
+print(f'  VIRAC e_pm > {JW_FLOOR} (JW-VVV more precise): {rescued.sum()} ({100*rescued.mean():.0f}%)')
+print(f'  VIRAC e_pm > 3 (VIRAC PM unusable, JW rescues): {strong.sum()} ({100*strong.mean():.0f}%)')
+print(f'  VIRAC e_pm < 1 (both good, cross-validation):   {(epm<1).sum()} ({100*(epm<1).mean():.0f}%)')
+
+# whole-catalog usable-PM counts at matched quality (~2 mas/yr)
+allpm = Table.read('/orange/adamginsburg/jwst/brick/astrometry_retie_qualcuts_20251211/refcache/virac2.fits')
+eall = np.hypot(np.asarray(allpm['e_pmRA'],float), np.asarray(allpm['e_pmDE'],float))
+print(f'\nwhole VIRAC2 footprint {len(allpm)}: e_pm<2 usable {int((eall<2).sum())} ({100*(eall<2).mean():.0f}%)')
+
+# ---- bulk motion + residuals -------------------------------------------------
+pra = np.asarray(tr['pm_ra'], float); pde = np.asarray(tr['pm_dec'], float)
+bulk_ra, bulk_de = np.median(pra), np.median(pde)
+rra, rde = pra - bulk_ra, pde - bulk_de
+print(f'\nbulk PM (median, VIRAC frame): ({bulk_ra:+.2f},{bulk_de:+.2f}) mas/yr; '
+      f'dispersion ({np.std(rra):.2f},{np.std(rde):.2f})')
+
+# ---- figure ------------------------------------------------------------------
+fig = plt.figure(figsize=(15, 9))
+# A: VPD raw
+axA = fig.add_subplot(2, 3, 1)
+axA.hexbin(pra, pde, gridsize=45, cmap='viridis', mincnt=1, extent=[-25,25,-25,25])
+axA.plot(bulk_ra, bulk_de, 'r+', ms=16, mew=2)
+axA.set_xlim(-25,25); axA.set_ylim(-25,25); axA.set_aspect('equal')
+axA.set_xlabel('pm_RA (mas/yr)'); axA.set_ylabel('pm_Dec (mas/yr)')
+axA.set_title(f'JW-VVV VPD (trustworthy n={n})\nbulk ({bulk_ra:+.1f},{bulk_de:+.1f})')
+# B: bulk-subtracted VPD
+axB = fig.add_subplot(2, 3, 2)
+axB.hexbin(rra, rde, gridsize=45, cmap='magma', mincnt=1, extent=[-20,20,-20,20])
+th=np.linspace(0,2*np.pi,100)
+for r in (5,10): axB.plot(r*np.cos(th), r*np.sin(th), 'w-', lw=0.5, alpha=0.5)
+axB.set_xlim(-20,20); axB.set_ylim(-20,20); axB.set_aspect('equal')
+axB.set_xlabel('Δpm_RA (mas/yr)'); axB.set_ylabel('Δpm_Dec (mas/yr)')
+axB.set_title('bulk-subtracted VPD')
+# C: spatial residual-PM vector field
+axC = fig.add_subplot(2, 3, 3)
+ra0 = np.asarray(tr['ra0'], float); dec0 = np.asarray(tr['dec0'], float)
+q = axC.quiver(ra0, dec0, rra, rde, np.hypot(rra,rde), cmap='plasma',
+               scale=180, width=0.003, clim=(0,12))
+axC.invert_xaxis(); axC.set_aspect('equal', adjustable='datalim')
+axC.set_xlabel('RA (deg)'); axC.set_ylabel('Dec (deg)')
+axC.set_title('residual PM vectors (bulk removed)')
+fig.colorbar(q, ax=axC, label='|Δpm| (mas/yr)', shrink=0.8)
+# D: rescue - e_pm vs Ks with JW floor
+axD = fig.add_subplot(2, 3, 4)
+axD.scatter(tr['Ks'], epm, s=4, alpha=0.3, label='VIRAC e_pm (trustworthy)')
+axD.axhline(JW_FLOOR, color='r', lw=1.5, label=f'JW-VVV floor {JW_FLOOR}')
+axD.axhline(3, color='orange', ls='--', lw=1, label='VIRAC unusable (3)')
+axD.set_xlabel('Ks (mag)'); axD.set_ylabel('VIRAC e_pm_tot (mas/yr)')
+axD.set_ylim(0,15); axD.legend(fontsize=7); axD.set_title('precision rescue vs magnitude')
+# E: cumulative usable-PM count vs threshold
+axE = fig.add_subplot(2, 3, 5)
+thr = np.linspace(0.5, 8, 60)
+axE.plot(thr, [ (eall<t).sum() for t in thr ], label='VVV-only usable (e_pm<t)')
+axE.axhline(n, color='seagreen', lw=1.5, label=f'JW-VVV trustworthy ({n}, ~{JW_FLOOR})')
+axE.set_xlabel('PM error threshold (mas/yr)'); axE.set_ylabel('N stars usable')
+axE.legend(fontsize=7); axE.set_title('usable-PM yield vs precision cut')
+# F: text summary
+axF = fig.add_subplot(2, 3, 6); axF.axis('off')
+txt = (f'YIELD (F212N, VIRAC2 frame)\n'
+       f'  VVV-only (any PM):      34,488\n'
+       f'  VVV-only usable e_pm<2: {int((eall<2).sum()):,}\n'
+       f'  JW-VVV trustworthy:     {n:,}\n\n'
+       f'PRECISION RESCUE (of trustworthy)\n'
+       f'  VIRAC e_pm>{JW_FLOOR}: {rescued.sum()} ({100*rescued.mean():.0f}%)\n'
+       f'  VIRAC e_pm>3 (unusable): {strong.sum()} ({100*strong.mean():.0f}%)\n\n'
+       f'DEPTH RESCUE (fainter than VIRAC2)\n'
+       f'  VIRAC2 rolls over Ks~17;\n'
+       f'  no position-only VVV catalog\n'
+       f'  reachable (VSA down) -> minimal\n\n'
+       f'JW-VVV floor {JW_FLOOR} mas/yr set by\n'
+       f'VIRAC 2014 POSITION err (~3.6mas),\n'
+       f'NOT its PM err -> flat vs Ks')
+axF.text(0.02, 0.98, txt, va='top', ha='left', fontsize=9, family='monospace')
+fig.suptitle('JW-VVV proper motions: VPD, spatial residuals, and the precision-rescue of faint VIRAC PMs', fontsize=12)
+fig.tight_layout()
+fig.savefig(f'{OUT}/pm_vpd_and_rescue.png', dpi=130, bbox_inches='tight')
+print('wrote', f'{OUT}/pm_vpd_and_rescue.png')

--- a/brick2221/analysis/pm_vs_extinction.py
+++ b/brick2221/analysis/pm_vs_extinction.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Mean proper-motion vector +/- dispersion vs extinction, using JWST photometry
+(F200W-F444W, CT06_MWGC law) for A_V.  Trustworthy JW-VVV PMs only.
+
+Expectation (Brick): low A_V = foreground disk (distinct mean PM, low sigma);
+high A_V = embedded CMZ population (bulk CMZ motion, higher sigma).
+"""
+import numpy as np
+import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+from dust_extinction.averages import CT06_MWGC
+
+OUT = '/orange/adamginsburg/jwst/brick/astrometry_diag/pm_flystar'
+SNAP = '/blue/adamginsburg/adamginsburg/jwst/brick/astrometry_diag/m8_dedup_1182_snapshot_20260708.fits'
+
+pm = Table.read(f'{OUT}/pm_jwst_virac_f212n.fits')
+tr = pm[pm['trustworthy']]
+pmc = SkyCoord(np.asarray(tr['ra0'])*u.deg, np.asarray(tr['dec0'])*u.deg)
+
+# ---- JWST extinction: F200W - F444W, CT06_MWGC (cleaned photometry) ----------
+s = Table.read(SNAP)
+sc = s['skycoord_f200w']
+m200 = np.asarray(s['mag_ab_f200w'], float); m444 = np.asarray(s['mag_ab_f444w'], float)
+f200 = np.asarray(s['flux_jy_f200w'], float); e200 = np.asarray(s['eflux_jy_f200w'], float)
+f444 = np.asarray(s['flux_jy_f444w'], float); e444 = np.asarray(s['eflux_jy_f444w'], float)
+ff200 = np.asarray(s['forced_filled_f200w']) if 'forced_filled_f200w' in s.colnames else np.zeros(len(s), bool)
+ff444 = np.asarray(s['forced_filled_f444w']) if 'forced_filled_f444w' in s.colnames else np.zeros(len(s), bool)
+clean = (np.isfinite(sc.ra.deg) & np.isfinite(m200) & np.isfinite(m444)
+         & (f200/e200 > 10) & (f444/e444 > 10) & ~ff200.astype(bool) & ~ff444.astype(bool))
+ssc = SkyCoord(sc.ra.deg[clean]*u.deg, sc.dec.deg[clean]*u.deg)
+m200c, m444c = m200[clean], m444[clean]
+idx, sep, _ = pmc.match_to_catalog_sky(ssc)
+law = CT06_MWGC()
+coeff = float(law(2.0*u.um) - law(4.44*u.um))     # E(F200W-F444W)/A_V
+color = m200c[idx] - m444c[idx]
+# foreground zero-point: least-reddened 5% ~ disk stars -> A_V = 0 there
+c0 = np.percentile(color[sep < 0.3*u.arcsec], 5)
+AV = (color - c0) / coeff
+print(f'matched clean broadbands: {(sep<0.3*u.arcsec).sum()}/{len(tr)};  '
+      f'CT06 E(F200W-F444W)/A_V={coeff:.3f}; foreground color0={c0:.2f}')
+
+pra = np.asarray(tr['pm_ra'], float); pde = np.asarray(tr['pm_dec'], float)
+# clip color outliers (mismatches) to a physical A_V window
+sel = (sep < 0.3*u.arcsec) & np.isfinite(AV) & (AV > -5) & (AV < 60) & np.isfinite(pra) & np.isfinite(pde)
+AV, pra, pde = AV[sel], pra[sel], pde[sel]
+print(f'AV range p5/p50/p95: {np.percentile(AV,[5,50,95]).round(1)}  N={sel.sum()}')
+
+# ---- bin by A_V (equal-N quantile bins) --------------------------------------
+nbin = 7
+edges = np.quantile(AV, np.linspace(0, 1, nbin+1))
+edges[0] -= 1e-6; edges[-1] += 1e-6
+ib = np.digitize(AV, edges) - 1
+rows = []
+for b in range(nbin):
+    m = ib == b
+    if m.sum() < 20: continue
+    n = m.sum()
+    mra, mde = np.mean(pra[m]), np.mean(pde[m])
+    sra, sde = np.std(pra[m], ddof=1), np.std(pde[m], ddof=1)
+    rows.append(dict(av=np.median(AV[m]), n=n, mra=mra, mde=mde, sra=sra, sde=sde,
+                     era=sra/np.sqrt(n), ede=sde/np.sqrt(n),
+                     stot=np.sqrt(0.5*(sra**2+sde**2))))
+B = Table(rows)
+print('\n  A_V    N   <pmRA>    <pmDE>    sig_RA sig_DE sig_tot')
+for r in B:
+    print(f'{r["av"]:6.1f} {r["n"]:4d}  {r["mra"]:+6.2f}   {r["mde"]:+6.2f}    {r["sra"]:5.2f}  {r["sde"]:5.2f}  {r["stot"]:5.2f}')
+B.write(f'{OUT}/pm_vs_extinction_bins.fits', overwrite=True)
+
+# ---- figure ------------------------------------------------------------------
+fig = plt.figure(figsize=(15, 9))
+# A: mean pmRA, pmDE vs A_V (error bars = dispersion)
+axA = fig.add_subplot(2, 3, 1)
+axA.errorbar(B['av'], B['mra'], yerr=B['sra'], fmt='o-', color='C0', label='<pmRA> +/- disp', capsize=3)
+axA.errorbar(B['av']+0.3, B['mde'], yerr=B['sde'], fmt='s-', color='C1', label='<pmDE> +/- disp', capsize=3)
+axA.axhline(0, color='k', lw=0.5)
+axA.set_xlabel('A_V (JWST F200W-F444W, CT06)'); axA.set_ylabel('mean PM (mas/yr)')
+axA.legend(fontsize=8); axA.set_title('mean PM vector vs extinction (bars=dispersion)')
+# A2: same but bars = error on the mean (is the mean SHIFT significant?)
+axB = fig.add_subplot(2, 3, 2)
+axB.errorbar(B['av'], B['mra'], yerr=B['era'], fmt='o-', color='C0', label='<pmRA> +/- SEM', capsize=3)
+axB.errorbar(B['av']+0.3, B['mde'], yerr=B['ede'], fmt='s-', color='C1', label='<pmDE> +/- SEM', capsize=3)
+axB.axhline(0, color='k', lw=0.5)
+axB.set_xlabel('A_V'); axB.set_ylabel('mean PM (mas/yr)')
+axB.legend(fontsize=8); axB.set_title('mean PM vs extinction (bars=SEM)')
+# C: dispersion vs A_V
+axC = fig.add_subplot(2, 3, 3)
+axC.plot(B['av'], B['sra'], 'o-', label='sigma_RA')
+axC.plot(B['av'], B['sde'], 's-', label='sigma_Dec')
+axC.plot(B['av'], B['stot'], '^-', color='k', label='sigma_tot')
+axC.set_xlabel('A_V'); axC.set_ylabel('PM dispersion (mas/yr)')
+axC.legend(fontsize=8); axC.set_title('PM dispersion vs extinction')
+# D: PM vectors per A_V bin (from origin), colored by A_V
+axD = fig.add_subplot(2, 3, 4)
+cmap = plt.cm.viridis((B['av']-B['av'].min())/(np.ptp(B["av"])+1e-9))
+for r, c in zip(B, cmap):
+    axD.arrow(0, 0, r['mra'], r['mde'], color=c, width=0.03, head_width=0.15,
+              length_includes_head=True)
+    axD.add_patch(plt.Circle((r['mra'], r['mde']), r['stot'], ec=c, fc='none', lw=0.8, alpha=0.6))
+axD.axhline(0, color='k', lw=0.3); axD.axvline(0, color='k', lw=0.3)
+axD.set_xlim(-8, 4); axD.set_ylim(-10, 2); axD.set_aspect('equal')
+axD.set_xlabel('<pmRA> (mas/yr)'); axD.set_ylabel('<pmDE> (mas/yr)')
+axD.set_title('mean PM vector per A_V bin (circle=sigma_tot)')
+# E: N vs A_V
+axE = fig.add_subplot(2, 3, 5)
+axE.bar(range(len(B)), B['n']); axE.set_xticks(range(len(B)))
+axE.set_xticklabels([f'{a:.0f}' for a in B['av']], fontsize=8)
+axE.set_xlabel('A_V bin (median)'); axE.set_ylabel('N stars'); axE.set_title('stars per bin')
+# F: VPD colored by A_V
+axF = fig.add_subplot(2, 3, 6)
+sctr = axF.scatter(pra, pde, c=AV, s=5, cmap='viridis', alpha=0.5)
+axF.set_xlim(-20,15); axF.set_ylim(-22,12); axF.set_aspect('equal')
+axF.set_xlabel('pmRA (mas/yr)'); axF.set_ylabel('pmDec (mas/yr)')
+fig.colorbar(sctr, ax=axF, label='A_V'); axF.set_title('VPD colored by A_V')
+fig.suptitle('JW-VVV proper motion vs JWST extinction (trustworthy set)', fontsize=13)
+fig.tight_layout()
+fig.savefig(f'{OUT}/pm_vs_extinction.png', dpi=130, bbox_inches='tight')
+print('wrote', f'{OUT}/pm_vs_extinction.png')

--- a/brick2221/analysis/verify_1182_model_residual.py
+++ b/brick2221/analysis/verify_1182_model_residual.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Verify the 1182 F200W crowdsource model & residual mosaics are right:
+data | model | residual at the PM-discrepancy pair positions.  A correct model
+reproduces both resolved stars and leaves a flat residual (no star-shaped
+positive/negative residuals) -> catalog positions & fluxes are trustworthy."""
+import numpy as np
+import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.coordinates import SkyCoord
+from astropy.nddata import Cutout2D
+from astropy import units as u
+from astropy.table import Table
+
+P = '/orange/adamginsburg/jwst/brick/F200W/pipeline'
+DATA = f'{P}/jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits'
+MODEL = f'{P}/jw01182-o004_t001_nircam_clear-f200w-merged_resbgsub_m7_daophot_basic_mergedcat_model_i2d.fits'
+RESID = f'{P}/jw01182-o004_t001_nircam_clear-f200w-merged_resbgsub_m7_daophot_basic_mergedcat_residual_i2d.fits'
+TOP = '/orange/adamginsburg/jwst/brick/astrometry_diag/pm_binaries/pm_discrepancy_top.fits'
+OUT = '/orange/adamginsburg/jwst/brick/astrometry_diag/pm_binaries/verify_1182_model_residual.png'
+
+d = fits.open(DATA, memmap=True); dd, dw = d[1].data, WCS(d[1].header)
+m = fits.open(MODEL, memmap=True); md, mw = m[1].data, WCS(m[1].header)
+rf = fits.open(RESID, memmap=True); rd, rw = rf[1].data, WCS(rf[1].header)
+top = Table.read(TOP)
+
+pick = [0, 4, 9, 10]              # bright, clean pairs
+CUT = 2.5*u.arcsec
+fig, axes = plt.subplots(len(pick), 3, figsize=(9, 3.0*len(pick)), squeeze=False)
+for r, ti in enumerate(pick):
+    c = SkyCoord(top['ra'][ti]*u.deg, top['dec'][ti]*u.deg)
+    cuts = []
+    for (data, wcs) in [(dd, dw), (md, mw), (rd, rw)]:
+        cuts.append(Cutout2D(data, c, CUT, wcs=wcs))
+    # shared stretch from the data cutout
+    di = cuts[0].data.astype(float); fin = np.isfinite(di) & (di != 0)
+    lo, hi = np.nanpercentile(di[fin], [3, 99.7])
+    for col, (cut, name) in enumerate(zip(cuts, ['data', 'model', 'residual'])):
+        ax = axes[r][col]; img = cut.data.astype(float); ny, nx = img.shape
+        ax.imshow(img, origin='lower', cmap='gray', vmin=lo, vmax=hi)
+        ax.set_xlim(-0.5, nx-0.5); ax.set_ylim(-0.5, ny-0.5)
+        cx, cy = cut.wcs.world_to_pixel(c); ax.plot(cx, cy, '+', color='cyan', ms=11, mew=1.5)
+        ax.set_xticks([]); ax.set_yticks([])
+        if r == 0: ax.set_title(name, fontsize=10)
+        if col == 0:
+            ax.set_ylabel(f'#{ti} sep={top["compsep"][ti]:.2f}"\nKs={top["Ks"][ti]:.1f}', fontsize=8)
+        if col == 2:  # residual RMS relative to data peak, as a subtraction-quality number
+            rr = img[np.isfinite(img)]
+            frac = np.std(rr) / (hi - lo)
+            ax.text(0.03, 0.03, f'resid std/data-range={frac:.2f}', color='yellow',
+                    fontsize=7, transform=ax.transAxes)
+fig.suptitle('1182 F200W m7: data | model | residual  (cyan+ = VIRAC pos).  '
+             'Flat residual at pair = correct model.', fontsize=10)
+fig.tight_layout()
+fig.savefig(OUT, dpi=130, bbox_inches='tight')
+print('wrote', OUT)

--- a/brick2221/analysis/verify_v001_fix.py
+++ b/brick2221/analysis/verify_v001_fix.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Post-reduction verification for the 1182 v001 ~20" offset fix.
+Checks, per broadband: the regenerated crf carries the corrected RAOFFSET
+(v001 ~-17.5, v002 ~+1.9) and the crf native offset vs VIRAC2 collapses to ~0
+for v001 (was ~20"). PASS iff v001 crf is now < 0.1" from VIRAC2.
+"""
+import glob, os, time
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, search_around_sky
+from astropy import units as u
+import warnings; warnings.filterwarnings('ignore')
+from photutils.detection import DAOStarFinder
+
+v = Table.read('/orange/adamginsburg/jwst/brick/astrometry_retie_qualcuts_20251211/refcache/virac2.fits')
+vra = np.asarray(v['RAJ2000'], float); vde = np.asarray(v['DEJ2000'], float)
+pr = np.nan_to_num(np.asarray(v['pmRA'], float)); pd = np.nan_to_num(np.asarray(v['pmDE'], float))
+cosd = np.cos(np.radians(vde))
+vsc = SkyCoord((vra+pr*8.7/3.6e6/cosd)*u.deg, (vde+pd*8.7/3.6e6)*u.deg)
+
+def native_off(path, rad=30):
+    h = fits.open(path, memmap=True); e = 1 if h[0].data is None else 0
+    d = h[e].data.astype(float); w = WCS(h[e].header); std = np.nanstd(d[np.isfinite(d)])
+    src = DAOStarFinder(fwhm=2.5, threshold=25*std)(np.nan_to_num(d-np.nanmedian(d)))
+    if src is None or len(src) < 15: return None
+    sky = w.pixel_to_world(src['xcentroid'], src['ycentroid'])
+    i1, i2, _, _ = search_around_sky(sky, vsc, rad*u.arcsec)
+    if len(i1) < 15: return None
+    dra = (sky.ra.deg[i1]-vsc.ra.deg[i2])*np.cos(np.radians(sky.dec.deg[i1]))*3600
+    dde = (sky.dec.deg[i1]-vsc.dec.deg[i2])*3600
+    b = 0.05; ee = np.arange(-rad, rad+b, b); H, xe, ye = np.histogram2d(dra, dde, bins=[ee, ee])
+    iy, ix = np.unravel_index(np.argmax(H.T), H.T.shape)
+    return 0.5*(xe[ix]+xe[ix+1]), 0.5*(ye[iy]+ye[iy+1]), int(H.max())
+
+P = '/orange/adamginsburg/jwst/brick'
+FILT = {'F115W': '02101', 'F200W': '04101', 'F356W': '02101', 'F444W': '04101'}
+allpass = True
+print('band  visit  crf_RAOFFSET(applied)   native_off_vs_VIRAC   verdict')
+for band in ['F115W', 'F200W', 'F356W', 'F444W']:
+    d = band; sw = band in ('F115W', 'F200W')
+    det = 'nrca1' if sw else 'nrcalong'
+    for vis in ['jw01182004001', 'jw01182004002']:
+        g = sorted(glob.glob(f'{P}/{d}/pipeline/{vis}_*_00001_{det}_destreak_o004_crf.fits'))
+        if not g:
+            print(f'{band} {vis[-3:]}: crf MISSING'); allpass = False; continue
+        crf = g[0]; h = fits.getheader(crf, 1)
+        ra_off, de_off = h.get('RAOFFSET'), h.get('DEOFFSET')
+        off = native_off(crf); mt = time.ctime(os.path.getmtime(crf))[4:16]
+        if off is None:
+            print(f'{band} {vis[-3:]}: RAOFFSET=({ra_off:+.2f},{de_off:+.2f}) native=? {mt}'); continue
+        mag = np.hypot(off[0], off[1])
+        ok = mag < 0.10
+        if vis.endswith('001') and not ok: allpass = False
+        print(f'{band} {vis[-3:]}: RAOFFSET=({ra_off:+7.2f},{de_off:+6.2f})  native=({off[0]:+6.2f},{off[1]:+6.2f})\" |{mag:5.2f}|  {"PASS" if ok else "FAIL"}  {mt}')
+print('\n==== OVERALL:', 'PASS - v001 aligned to VIRAC2' if allpass else 'FAIL / incomplete', '====')


### PR DESCRIPTION
Adds nine analysis tools (`brick2221/analysis/`) built while auditing brick 1182+2221 astrometry and measuring JWST-VVV proper motions.

## Proper motions
- **pm_jwst_virac_flystar.py** - JWST(F200W/F212N)xVIRAC2 2-epoch PM via flystar; constant-shift tie, flux-vetted match, isolation filter for trustworthy PMs.
- **pm_vpd_and_rescue.py** - VPD, bulk-subtracted VPD, spatial residual map, precision-rescue quantification (VIRAC2 is PM-complete -> JWST gain is precision + blend-rejection, not count).
- **pm_vs_extinction.py** - mean PM vector +/- dispersion vs A_V (F200W-F444W, CT06_MWGC): foreground-disk -> embedded-CMZ transition.
- **pm_discrepancy_binaries.py** - largest VIRAC-vs-(JWST-VIRAC) PM discrepancy = sub-arcsec VVV blends; VVV(H)+JWST(F200W) cutouts.

## Astrometry / matching quality
- **brick_match_quality_review.py** - band-to-band / cross-obs (1182<->2221) / JWST<->VIRAC matching quality.
- **f200w_virac_mag_astrom_test.py** - F200W<->VIRAC mag agreement + astrometry; arcsec offsets are footprint non-counterparts, not catalog error.
- **i2d_offset_audit.py** - per-i2d-mosaic WCS offset vs catalog by bright-star centroiding; flags stale/untied mosaics.
- **verify_1182_model_residual.py** - 1182 F200W data|model|residual PSF-subtraction check.
- **verify_v001_fix.py** - post-reduction verifier for the 1182 visit-001 ~20" offset fix (crf RAOFFSET + native offset-histogram vs VIRAC2).

## Method note
All measure systematic offsets with the **2D-mode offset-histogram** (peak + concentration + core-MAD), NOT nearest-neighbour mean/median - the latter mispairs in the confusion-limited Brick and hides large (~20") per-visit offsets. These tools drove the diagnosis + verification of the 1182 visit-001 ~20" astrometry bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuS3FoGu52XvrEvv8EY6jK