### PR TITLE
gate: histogram stacking + per-tile + Gaia (not dense-NN-median)

### DIFF
--- a/brick2221/analysis/verify_brick_regressions.py
+++ b/brick2221/analysis/verify_brick_regressions.py
@@ -1,49 +1,62 @@
 #!/usr/bin/env python
-"""Brick final-merge regression gate — GENUINE source-to-source checks (not
-histogram/xcorr) with flux-agreement filtering.  Run after the re-merge chain
-(reduce->verify->catalog->m7) completes.  Exit 0 only if every check PASSES.
+"""Brick final-merge regression gate.
 
-Checks (all use nearest-neighbour matching on already-aligned data — valid because
-the post-fix residual << match radius — with a flux-agreement inlier cut to reject
-blends/mismatches):
+Run after the re-merge chain (reduce->verify->catalog->m7) completes.  Exit 0 only
+if every check PASSES.
 
-  1. 1182 <-> 2221 agree, source-to-source, flux-checked (F200W[1182] vs F212N[2221]).
-  2. Both agree with VIRAC2 within survey noise, flux-filtered (F212N~F200W~K-band).
-  3. No systematic offset BETWEEN MODULES (per-module i2d vs VIRAC2; catches the
-     F410M nrca/nrcb misalignment regression).
-  4. EVERY combined i2d mosaic's WCS matches the final catalog (loop closure /
-     by-eye check made quantitative) -- the critical one.
+**Measurement method: offset-HISTOGRAM stacking, NOT nearest-neighbour median.**
+Earlier versions matched detected sources to the dense VIRAC2 with
+``match_to_catalog_sky`` within a 0.3" radius, then took the median.  That is the
+forbidden dense-NN-median method: it *assumes* the data is already aligned (a source
+>0.3" off has no match in the window, gets discarded, and the survivors always look
+aligned), so it CANNOT detect the very regression this gate exists to catch -- a
+visit-collapse can leave a whole visit ~20" off and the gate still passes.  It also
+took ONE whole-mosaic median, which averages a half-mosaic seam to ~0.  Both are
+exactly how the brick-1182 visit-001 break hid.
 
-Thresholds are deliberately survey-noise-scaled, not zero.
+This version uses ``jwst_gc_pipeline.photometry.astrometry_offsets``:
+  * ``measure_offset``       -- window-swept histogram, density-immune, finds a 20"
+                                offset instead of dropping it;
+  * ``measure_offset_grid``  -- PER-TILE map, so a y=0.5 half-mosaic seam cannot hide
+                                behind a ~0 bulk;
+  * ``agree_across_references`` -- the tie must agree between VIRAC2 (dense) AND a
+                                Gaia-only (sparse) reference; a spurious peak is
+                                reference-dependent.
+
+Checks:
+  1. 1182 <-> 2221 source-to-source (F200W[1182] vs F212N[2221]).
+  2. Each 1182/2221 mosaic ties VIRAC2 -- PER TILE (no seam) AND VIRAC-Gaia agree.
+  3. No systematic offset BETWEEN MODULES (per-module i2d vs VIRAC2).
+  4. EVERY combined i2d WCS matches the final catalog (loop closure).
+Thresholds are survey-noise-scaled, not zero.
 """
-import argparse, glob, os, sys, re
+import argparse, glob, os, sys
 import numpy as np, astropy.units as u
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
-from astropy.stats import sigma_clipped_stats, mad_std
+from astropy.stats import sigma_clipped_stats
 from photutils.detection import DAOStarFinder
+
+from jwst_gc_pipeline.photometry.astrometry_offsets import (
+    measure_offset, measure_offset_grid, agree_across_references)
 
 BASE = "/orange/adamginsburg/jwst/brick"
 REL = "/orange/adamginsburg/jwst/releases/v1.0-2026.06/brick"
-# VIRAC2 cache carries Ksmag (needed for the flux-agreement filter) + pmRA/pmDE
-# (propagated to OBS_EP below). The epoch-baked gaia_virac2_refcat_*.fits has no Ks.
 REFCAT = f"{BASE}/astrometry_diag/refcache/virac2.fits"
+# Epoch-baked Gaia+VIRAC2 refcat carries a 'source' column -> Gaia-only sparse subset
+# for the two-reference agreement check.
+GAIA_REFCAT = f"{BASE}/catalogs/gaia_virac2_refcat_epoch2022.70.fits"
 V2EP = 2014.0
 OBS_EP = 2022.703
-MATCH_R = 0.30 * u.arcsec        # NN radius (post-fix residual is <<0.3")
-# survey-noise-scaled PASS thresholds (median on-sky offset, mas)
-# module threshold is PM-grade (a static A/B offset -> spurious proper motion):
-# 74 mas over the ~7 yr baseline is ~10 mas/yr, so keep this tight.
-# 2026-07-05: the filteroffset module-swap fix removed the F356W 74 mas anomaly, but
-# exposed a pre-existing COMMON ~20-24 mas inter-module residual across ALL 1182 bands
-# (the Dec -28.71 A/B seam / NRCB per-detector distortion residual not removed by the
-# single module-locked shift). SHIPPING that known residual for now -> module relaxed
-# 15 -> 30 mas so it passes while still catching gross regressions. The definitive fix
-# is the per-module 2-shift tie (build_virac2_locked_perexp.py --per-module); once that
-# re-reduction lands, tighten this back to 15 (PM-grade).
-THRESH = dict(cross=40.0, virac2=70.0, module=30.0, loop=50.0)
+
+# survey-noise-scaled PASS thresholds (median on-sky offset, mas).
+# module threshold is PM-grade; 30 mas ships the known ~20-24 mas inter-module
+# residual for now -> tighten to 15 after the per-module re-reduction.  seam gates the
+# WORST per-tile offset (catches half-mosaic breaks); ref_agree gates VIRAC-vs-Gaia.
+THRESH = dict(cross=40.0, virac2=70.0, module=30.0, loop=50.0,
+              seam=150.0, ref_agree=100.0)
 
 
 def farr(x):
@@ -55,56 +68,46 @@ def virac2():
     ra, dec = farr(v["RAJ2000"]), farr(v["DEJ2000"])
     pr = np.nan_to_num(farr(v["pmRA"])); pd = np.nan_to_num(farr(v["pmDE"]))
     dt = OBS_EP - V2EP
-    sc = SkyCoord((ra + (pr * dt / 3.6e6) / np.cos(np.radians(dec))) * u.deg,
-                  (dec + pd * dt / 3.6e6) * u.deg)
-    ks = farr(v["Ksmag"]) if "Ksmag" in v.colnames else np.full(len(v), np.nan)
-    return sc, ks
+    return SkyCoord((ra + (pr * dt / 3.6e6) / np.cos(np.radians(dec))) * u.deg,
+                    (dec + pd * dt / 3.6e6) * u.deg)
+
+
+def gaia_only():
+    """Sparse Gaia-only reference (source == b'GaiaDR3') for the two-ref agreement."""
+    if not os.path.exists(GAIA_REFCAT):
+        return None
+    t = Table.read(GAIA_REFCAT)
+    if 'source' not in t.colnames or 'skycoord' not in t.colnames:
+        return None
+    m = np.asarray(t['source']) == b'GaiaDR3'
+    return SkyCoord(t['skycoord'][m]) if m.any() else None
 
 
 def detect(path, thr=50.0, fwhm=2.5):
-    """Return (SkyCoord, instrumental_mag) of sources on an i2d SCI plane."""
+    """(SkyCoord) of sources on an i2d SCI plane.  No flux filter -- histogram
+    stacking is robust to blends/mismatches (unlike the old NN median)."""
     h = fits.open(path); sci = h["SCI"]; w = WCS(sci.header); d = sci.data.astype("float32")
     _, med, std = sigma_clipped_stats(d, sigma=3.0)
     t = DAOStarFinder(fwhm=fwhm, threshold=thr * std)(d - med)
     if t is None or len(t) == 0:
-        return SkyCoord([], [], unit=u.deg), np.array([])
-    sc = SkyCoord(w.pixel_to_world(t["xcentroid"], t["ycentroid"]))
-    flux = np.asarray(t["flux"], float)
-    imag = -2.5 * np.log10(np.clip(flux, 1e-9, None))
-    return sc, imag
+        return SkyCoord([], [], unit=u.deg)
+    return SkyCoord(w.pixel_to_world(t["xcentroid"], t["ycentroid"]))
 
 
-def flux_inliers(m1, m2, nsig=3.0):
-    """Robust inlier mask for a linear mag1~mag2 relation (rejects blends/mismatches)."""
-    ok = np.isfinite(m1) & np.isfinite(m2)
-    if ok.sum() < 10:
-        return ok
-    d = m1[ok] - m2[ok]
-    c = np.abs(d - np.median(d)) < nsig * mad_std(d)
-    full = ok.copy(); full[ok] = c
-    return full
-
-
-def offset_mas(a, b):
-    """Genuine NN source-match a->b; return (median on-sky offset mas, dRA, dDec, N,
-    scatter_mas, matched-index arrays) after keeping only < MATCH_R matches."""
+def hist_off(a, b):
+    """Robust bulk offset a->b (mas) via window-swept histogram stacking. Returns a
+    compact dict(off, dra, ddec, ok, contrast, n) or None."""
     if len(a) == 0 or len(b) == 0:
         return None
-    idx, sep, _ = a.match_to_catalog_sky(b)
-    keep = sep < MATCH_R
-    if keep.sum() < 15:
+    r = measure_offset(a, b, sweep=True)
+    if r is None:
         return None
-    am, bm = a[keep], b[idx[keep]]
-    dra = (am.ra - bm.ra).to(u.arcsec).value * np.cos(am.dec.radian) * 1000.0
-    ddec = (am.dec - bm.dec).to(u.arcsec).value * 1000.0
-    return dict(off=float(np.hypot(np.median(dra), np.median(ddec))),
-                dra=float(np.median(dra)), ddec=float(np.median(ddec)),
-                n=int(keep.sum()), scatter=float(np.hypot(mad_std(dra), mad_std(ddec))),
-                keep=keep, idx=idx)
+    return dict(off=float(np.hypot(r["dra"], r["ddec"])), dra=r["dra"], ddec=r["ddec"],
+                ok=bool(r.get("ok")), contrast=float(r.get("contrast", 0.0)),
+                n=int(r.get("n", 0)))
 
 
 def i2d_path(filt, prop, module="merged"):
-    """Locate a combined i2d for (filter, proposal, module)."""
     pre = {"1182": "jw01182-o004", "2221": "jw02221-o001"}[prop]
     for tag in (f"-{filt.lower()}-{module}",):
         for root in (f"{REL}/images/{filt}", f"{BASE}/{filt}/pipeline"):
@@ -114,21 +117,17 @@ def i2d_path(filt, prop, module="merged"):
     return None
 
 
-STALE_DAYS = 2.0   # a per-module i2d older than its merged by more than this is a
-                   # leftover from a PRIOR reduction (not part of the current merge)
+STALE_DAYS = 2.0
 
 
 def is_fresh(module_path, merged_path):
-    """True if a per-module i2d belongs to the same reduction as its merged mosaic
-    (mtimes within STALE_DAYS). Filters out stale per-module leftovers (e.g. the
-    2024 2221 nrca/nrcb i2d that predate the 2026 merged by 2 years)."""
     if not module_path or not merged_path or not os.path.exists(module_path) \
        or not os.path.exists(merged_path):
         return False
     return (os.path.getmtime(merged_path) - os.path.getmtime(module_path)) < STALE_DAYS * 86400
 
 
-FILTERS = {  # filter -> proposal
+FILTERS = {
     "F115W": "1182", "F200W": "1182", "F356W": "1182", "F444W": "1182",
     "F182M": "2221", "F187N": "2221", "F212N": "2221",
     "F405N": "2221", "F410M": "2221", "F466N": "2221",
@@ -136,45 +135,43 @@ FILTERS = {  # filter -> proposal
 
 
 def check1_cross(cache):
-    print("\n[1] 1182 <-> 2221 source-to-source (F200W vs F212N), flux-checked")
-    a, ma = cache["F200W"]; b, mb = cache["F212N"]
-    if len(a) == 0 or len(b) == 0:
-        print("    SKIP (missing i2d)"); return None
-    idx, sep, _ = a.match_to_catalog_sky(b)
-    keep = sep < MATCH_R
-    am, mam = a[keep], ma[keep]; bm, mbm = b[idx[keep]], mb[idx[keep]]
-    fi = flux_inliers(mam, mbm)
-    r = offset_mas(am[fi], bm[fi])
-    if r is None:
-        print("    FAIL: too few flux-consistent matches"); return False
+    print("\n[1] 1182 <-> 2221 source-to-source (F200W vs F212N), histogram-stacked")
+    r = hist_off(cache["F200W"], cache["F212N"])
+    if r is None or not r["ok"]:
+        print("    FAIL: no coherent F200W<->F212N tie"); return False
     ok = r["off"] < THRESH["cross"]
-    print(f"    matched {r['n']} flux-consistent stars: dRA={r['dra']:+.1f} dDec={r['ddec']:+.1f} "
-          f"|{r['off']:.1f} mas| scatter={r['scatter']:.0f}mas  {'OK' if ok else 'FAIL'} (<{THRESH['cross']:.0f})")
+    print(f"    dRA={r['dra']:+.1f} dDec={r['ddec']:+.1f} |{r['off']:.1f} mas| C={r['contrast']:.0f} "
+          f"n={r['n']}  {'OK' if ok else 'FAIL'} (<{THRESH['cross']:.0f})")
     return ok
 
 
-def check2_virac2(cache, ref, ks):
-    print("\n[2] JWST <-> VIRAC2 within survey noise, flux-filtered (F212N~F200W~K)")
+def check2_virac2(cache, ref, gaia):
+    print("\n[2] JWST <-> VIRAC2 PER-TILE (no seam) + VIRAC2-vs-Gaia agreement")
     allok = True
     for filt in ("F200W", "F212N"):
-        sc, im = cache[filt]
+        sc = cache[filt]
         if len(sc) == 0:
             print(f"    {filt}: SKIP"); continue
-        idx, sep, _ = sc.match_to_catalog_sky(ref)
-        keep = sep < MATCH_R
-        fi = flux_inliers(im[keep], ks[idx[keep]])   # JWST instr mag vs VIRAC2 Ks
-        r = offset_mas(sc[keep][fi], ref[idx[keep]][fi])
-        if r is None:
-            print(f"    {filt}: FAIL (few flux-consistent matches)"); allok = False; continue
-        ok = r["off"] < THRESH["virac2"]
+        # (a) per-tile map -- catches a half-mosaic seam a bulk median would hide
+        grid = measure_offset_grid(sc, ref, nx=4, ny=4, context=f"{filt} vs VIRAC2")
+        clean = grid["clean"] and grid["worst_off_mas"] < THRESH["seam"]
+        # (b) two-reference agreement -- a spurious peak is reference-dependent
+        if gaia is not None:
+            ag = agree_across_references(sc, ref, gaia, tol_mas=THRESH["ref_agree"],
+                                         label_a="VIRAC2", label_b="Gaia")
+            agree = ag["agree"]; agtxt = f"VIRAC-Gaia={ag['sep_mas']:.0f}mas {'agree' if agree else 'DISAGREE'}"
+        else:
+            agree = True; agtxt = "(no Gaia)"
+        ok = clean and agree
         allok &= ok
-        print(f"    {filt}: {r['n']} K-consistent stars |{r['off']:.1f} mas| scatter={r['scatter']:.0f}"
-              f"  {'OK' if ok else 'FAIL'} (<{THRESH['virac2']:.0f})")
+        print(f"    {filt}: tiles {grid['n_ok']}/{grid['n_total']} tied, worst "
+              f"{grid['worst_off_mas']:.0f}mas, minC={grid['min_contrast_seen']:.0f}; {agtxt}"
+              f"  {'OK' if ok else 'FAIL'}")
     return allok
 
 
-def check3_modules(ref, ks):
-    print("\n[3] inter-module systematic offset (per-module i2d vs VIRAC2)")
+def check3_modules(ref):
+    print("\n[3] inter-module systematic offset (per-module i2d vs VIRAC2, histogram)")
     allok = True
     for filt, prop in FILTERS.items():
         merged = i2d_path(filt, prop, "merged")
@@ -186,12 +183,8 @@ def check3_modules(ref, ks):
             if not is_fresh(p, merged):
                 print(f"    {filt} {m}: SKIP (stale per-module i2d, predates merged)")
                 continue
-            sc, im = detect(p)
-            idx, sep, _ = sc.match_to_catalog_sky(ref)
-            keep = sep < MATCH_R
-            fi = flux_inliers(im[keep], ks[idx[keep]])
-            r = offset_mas(sc[keep][fi], ref[idx[keep]][fi])
-            if r:
+            r = hist_off(detect(p), ref)
+            if r and r["ok"]:
                 mods[m] = (r["dra"], r["ddec"], r["n"])
         if len(mods) == 2:
             (ax, ay, an), (bx, by, bn) = mods["nrca"], mods["nrcb"]
@@ -205,13 +198,11 @@ def check3_modules(ref, ks):
 
 def check4_loop(ref):
     print("\n[4] EVERY combined i2d WCS matches the final catalog (loop closure)")
-    # final catalog skycoord_ref (VIRAC2 frame). Fall back to VIRAC2 if catalog absent.
     catfn = f"{REL}/catalogs/basic_merged_indivexp_photometry_tables_merged_resbgsub_m7.fits"
     catfn = catfn if os.path.exists(catfn) else \
         f"{BASE}/catalogs/basic_merged_indivexp_photometry_tables_merged_resbgsub_m7.fits"
     if os.path.exists(catfn):
-        c = Table.read(catfn)
-        catc = SkyCoord(c["skycoord_ref"]); src = "catalog skycoord_ref"
+        c = Table.read(catfn); catc = SkyCoord(c["skycoord_ref"]); src = "catalog skycoord_ref"
     else:
         catc = ref; src = "VIRAC2 (catalog not found)"
     print(f"    reference = {src}")
@@ -227,12 +218,11 @@ def check4_loop(ref):
                 print(f"    {filt:6s} {m:6s} SKIP (stale, predates merged)")
                 continue
             seen.add(p)
-            sc, _ = detect(p)
-            r = offset_mas(sc, catc)
-            if r is None:
-                print(f"    {os.path.basename(p)}: no match (few stars?)"); continue
+            r = hist_off(detect(p), catc)
+            if r is None or not r["ok"]:
+                print(f"    {os.path.basename(p)}: no coherent tie (few stars?)"); continue
             ok = r["off"] < THRESH["loop"]; allok &= ok
-            print(f"    {filt:6s} {m:6s} |{r['off']:5.1f} mas| n={r['n']:5d}  "
+            print(f"    {filt:6s} {m:6s} |{r['off']:5.1f} mas| C={r['contrast']:.0f} n={r['n']:5d}  "
                   f"{'OK' if ok else 'FAIL'}")
     return allok
 
@@ -241,15 +231,19 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--checks", default="1234", help="subset e.g. 14")
     args = ap.parse_args()
-    ref, ks = virac2()
+    ref = virac2()
+    gaia = gaia_only()
+    if gaia is None:
+        print("WARNING: Gaia-only reference unavailable; check 2 runs VIRAC2-only "
+              "(no two-reference agreement -- a single dense ref can be fooled).")
     cache = {}
     for filt in ("F200W", "F212N"):
         p = i2d_path(filt, FILTERS[filt], "merged")
-        cache[filt] = detect(p) if p else (SkyCoord([], [], unit=u.deg), np.array([]))
+        cache[filt] = detect(p) if p else SkyCoord([], [], unit=u.deg)
     results = {}
     if "1" in args.checks: results["cross"] = check1_cross(cache)
-    if "2" in args.checks: results["virac2"] = check2_virac2(cache, ref, ks)
-    if "3" in args.checks: results["module"] = check3_modules(ref, ks)
+    if "2" in args.checks: results["virac2"] = check2_virac2(cache, ref, gaia)
+    if "3" in args.checks: results["module"] = check3_modules(ref)
     if "4" in args.checks: results["loop"] = check4_loop(ref)
     print("\n=== SUMMARY ===")
     for k, v in results.items():


### PR DESCRIPTION
Draft gate fix for #33 (targets #33's branch). Replaces the forbidden dense-NN-median measurement with the sanctioned histogram tools.

**Problem:** `verify_brick_regressions.py` matched sources to the dense VIRAC2 with `match_to_catalog_sky` within 0.3" then took the median. The 0.3" pre-match **discards any source further off**, so survivors always look aligned — the gate can't detect a visit-collapse that leaves a whole visit ~20" off, and one whole-mosaic median averages a half-mosaic seam to ~0 (exactly how brick-1182 v001 hid).

**Fix** (uses `jwst_gc_pipeline.photometry.astrometry_offsets`, now on main):
- `measure_offset` (window-swept histogram) on **raw** detected sources (no 0.3" pre-match) → finds a 20" offset instead of dropping it.
- check 2: `measure_offset_grid` (per-tile) so a y=0.5 seam FAILS instead of averaging away; + `agree_across_references` (VIRAC2 **and** Gaia-only must agree).
- checks 1/3/4 route through the histogram helper.

Drops the flux-inlier pre-filter (histogram stacking is robust to blends). Thresholds unchanged; adds `seam` (worst per-tile) + `ref_agree` (VIRAC-vs-Gaia) gates. `py_compile` clean, cross-repo import verified.

Merge order: land #34 (visit-collapse fix) → rebase #33 (per-visit-coarse + per-module) → this gate patch on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)