### PR TITLE
plotters: point at current pipeline i2d, not stale mosaics (~0.1" cutout offset)

### DIFF
--- a/brick2221/analysis/brick_rgb_images.py
+++ b/brick2221/analysis/brick_rgb_images.py
@@ -48,18 +48,21 @@ def save_rgb(img, filename, avm=None, flip=-1, alma_data=None, alma_level=None):
 
     return img
 
-# Updated image filenames for Brick data with correct project codes
+# Current drizzled pipeline mosaics (astrometry-corrected). Previously these
+# pointed at stale products -- 1182 at the images/ copies and 2221 at the
+# single-visit mastDownload/ i2d -- both of which predate the astrometry
+# corrections, so overlays/RGB landed ~0.1" off the true star positions.
 image_filenames_pipe = {
-    "f115w": "/orange/adamginsburg/jwst/brick/images/jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits",
-    "f182m": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o002_t001_nircam_clear-f182m_i2d.fits",
-    "f187n": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o001_t001_nircam_clear-f187n_i2d.fits",
-    "f200w": "/orange/adamginsburg/jwst/brick/images/jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits",
-    "f212n": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o001_t001_nircam_clear-f212n_i2d.fits",
-    "f356w": "/orange/adamginsburg/jwst/brick/images/jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits",
-    "f405n": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o001_t001_nircam_f405n-f444w_i2d.fits",
-    "f410m": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o001_t001_nircam_clear-f410m_i2d.fits",
-    "f444w": "/orange/adamginsburg/jwst/brick/images/jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits",
-    "f466n": "/orange/adamginsburg/jwst/brick/mastDownload/jw02221-o001_t001_nircam_f444w-f466n_i2d.fits",
+    "f115w": "/orange/adamginsburg/jwst/brick/F115W/pipeline/jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits",
+    "f182m": "/orange/adamginsburg/jwst/brick/F182M/pipeline/jw02221-o001_t001_nircam_clear-f182m-merged_i2d.fits",
+    "f187n": "/orange/adamginsburg/jwst/brick/F187N/pipeline/jw02221-o001_t001_nircam_clear-f187n-merged_i2d.fits",
+    "f200w": "/orange/adamginsburg/jwst/brick/F200W/pipeline/jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits",
+    "f212n": "/orange/adamginsburg/jwst/brick/F212N/pipeline/jw02221-o001_t001_nircam_clear-f212n-merged_i2d.fits",
+    "f356w": "/orange/adamginsburg/jwst/brick/F356W/pipeline/jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits",
+    "f405n": "/orange/adamginsburg/jwst/brick/F405N/pipeline/jw02221-o001_t001_nircam_clear-f405n-merged_i2d.fits",
+    "f410m": "/orange/adamginsburg/jwst/brick/F410M/pipeline/jw02221-o001_t001_nircam_clear-f410m-merged_i2d.fits",
+    "f444w": "/orange/adamginsburg/jwst/brick/F444W/pipeline/jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits",
+    "f466n": "/orange/adamginsburg/jwst/brick/F466N/pipeline/jw02221-o001_t001_nircam_clear-f466n-merged_i2d.fits",
 }
 
 # Commenting out subtracted images for now to get basic functionality working

--- a/brick2221/analysis/run_sed_satstar_brick.py
+++ b/brick2221/analysis/run_sed_satstar_brick.py
@@ -35,10 +35,13 @@ OUT_DIR = BRICK_BASE / 'sed_figures_f1500w_all'
 OUT_DIR.mkdir(exist_ok=True)
 
 IMAGE_FILES = {
-    'f115w': IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits',
-    'f200w': IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits',
-    'f356w': IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits',
-    'f444w': IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits',
+    # 1182 NIRCam: use the current drizzled pipeline mosaics, NOT the stale
+    # images/ copies -- those predate the astrometry corrections, so catalog
+    # positions land ~0.1" off the stars in the cutouts.
+    'f115w': BRICK_ORANGE / 'F115W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits',
+    'f200w': BRICK_ORANGE / 'F200W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits',
+    'f356w': BRICK_ORANGE / 'F356W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits',
+    'f444w': BRICK_ORANGE / 'F444W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits',
     'f182m': BRICK_ORANGE / 'F182M' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f182m-merged_i2d.fits',
     'f187n': BRICK_ORANGE / 'F187N' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f187n-merged_i2d.fits',
     'f212n': BRICK_ORANGE / 'F212N' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f212n-merged_i2d.fits',

--- a/brick2221/analysis/run_seds_nirspec6927.py
+++ b/brick2221/analysis/run_seds_nirspec6927.py
@@ -34,10 +34,12 @@ OUT_DIR     = BRICK_BASE / 'nirspec_6927' / 'sed_figures'
 OUT_DIR.mkdir(parents=True, exist_ok=True)
 
 IMAGE_FILES = {
-    'f115w':  IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits',
-    'f200w':  IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits',
-    'f356w':  IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits',
-    'f444w':  IMGS_DIR    / 'jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits',
+    # 1182 NIRCam: current drizzled pipeline mosaics, NOT the stale images/
+    # copies (those predate the astrometry corrections -> ~0.1" cutout offset).
+    'f115w':  BRICK_ORANGE / 'F115W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f115w-merged_i2d.fits',
+    'f200w':  BRICK_ORANGE / 'F200W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f200w-merged_i2d.fits',
+    'f356w':  BRICK_ORANGE / 'F356W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f356w-merged_i2d.fits',
+    'f444w':  BRICK_ORANGE / 'F444W' / 'pipeline' / 'jw01182-o004_t001_nircam_clear-f444w-merged_i2d.fits',
     'f182m':  BRICK_ORANGE / 'F182M' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f182m-merged_i2d.fits',
     'f187n':  BRICK_ORANGE / 'F187N' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f187n-merged_i2d.fits',
     'f212n':  BRICK_ORANGE / 'F212N' / 'pipeline' / 'jw02221-o001_t001_nircam_clear-f212n-merged_i2d.fits',


### PR DESCRIPTION
## Problem
The SED/cutout and RGB plotters read **stale JWST mosaics that predate the astrometry corrections**, so catalog positions and overlays land **~0.1″ (several pixels)** off the true stars — clearly visible by eye in the cutouts.

Verified reference-free (matched-pair, not argmax): the current `<FILTER>/pipeline/*-merged_i2d.fits` mosaics register to their own catalogs at ~1 pixel and pass the interframe-overlap check (worst 14–25 mas, v001↔v002 clean); the stale copies do not. Switching to the pipeline products makes catalog sources land on the stars (confirmed on 2221, which already used pipeline paths).

## Fix (3 tracked plotters, i2d paths only)
- **`run_sed_satstar_brick.py`** / **`run_seds_nirspec6927.py`** — the four **1182** filters (F115W/F200W/F356W/F444W) used the stale `images/` copies (Aug-2024, pre-correction). Repointed to `<FILTER>/pipeline/jw01182-o004_..._merged_i2d.fits`. *(The 2221 + MIRI entries were already correct pipeline paths — that's why 2221 cutouts already looked right.)*
- **`brick_rgb_images.py`** — 1182 used `images/` copies **and** 2221 used the **single-visit, uncorrected `mastDownload/`** i2d. Repointed all ten to the drizzled `<FILTER>/pipeline` mosaics (2221 → `jw02221-o001_..._merged_i2d.fits`).

All repointed paths verified to exist; all three files syntax-checked.

## Not in this PR — follow-ups
- **`brick2221/visualization/rgb_alma_plus_jwst.py`** — reads stale `images/` 2221 mosaics (F182M/F212N/F410M), but it is **untracked locally** (not on `main`); fix when it's committed.
- **`viz_slits.py`** — globs `images/*_i2d.fits` (stale); needs a glob repoint to the pipeline dirs.
- **Stale RGB PNG backgrounds** — `analysis_setup.py` (`img_nostars*`, `img_short_merged`) and `catalog_on_RGB.py` read pre-rendered RGB PNGs whose **embedded AVM WCS predates the corrections**. A path swap can't fix these — the PNGs must be **regenerated** from the current mosaics. Separate task.

## Root cause / prevention
Image i2d paths are **hardcoded per-script** (no central module — `catalog_paths.py` covers catalogs only). A future cleanup could add a `merged_i2d_path(filter)` helper so mosaic paths live in one place; out of scope here to keep the fix minimal and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qB97Yac6eoJiZr8Aq2Uww