### PR TITLE
WIP: AllFrame cutout photometry demo (detector-aware PSF)

### DIFF
--- a/allframe_cutout_demo.py
+++ b/allframe_cutout_demo.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+allframe_cutout_demo.py
+
+Simultaneous all-frame PSF photometry across every Sickle-field exposure
+(NIRCam SW + LW, all filters configured below) within a small benchmark
+cutout, using ``photutils.psf.AllFramePhotometry`` from the ``allframe``
+branch of photutils.
+
+Each input frame is a per-exposure subarray ``*_crf.fits`` calibrated
+image. We extract a small ``Cutout2D`` covering the benchmark region from
+every frame that overlaps it, then hand the per-frame
+(data, error, wcs, psf_model) tuples to ``AllFramePhotometry`` in joint
+mode with shared sky positions.
+
+Correct PSF location
+--------------------
+The stpsf grids are computed on the FULL detector. Every frame here is
+twice-offset from the detector frame:
+
+    detector_pixel = cutout_pixel
+                   + cutout_origin_in_subarray
+                   + (SUBSTRT - 1)
+
+So a naive call with cutout-frame (x_0, y_0) would interpolate the
+gridded PSF at the wrong place. To prevent this we wrap each
+``GriddedPSFModel`` in :class:`OffsetGriddedPSF`, which carries a frame-
+specific ``(dx, dy)`` cutout-to-detector shift and applies it inside
+``evaluate`` so the underlying grid is always sampled at the true
+detector location. No fallback or "near enough" PSF is ever used.
+
+Outputs
+-------
+``allframe_cutout_results.fits`` next to this script:
+    one row per source with shared (ra_fit, dec_fit) and
+    ``flux_fit_<i>``/``flux_err_<i>`` for every input frame.
+``allframe_cutout_frames.csv``:
+    bookkeeping table mapping frame index ``i`` →
+    (filter, detector, exposure, dx, dy).
+
+Usage
+-----
+    PYTHONPATH=/blue/adamginsburg/adamginsburg/repos/photutils-allframe \\
+        python allframe_cutout_demo.py
+"""
+
+import glob
+import os
+import re
+import sys
+
+import numpy as np
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.modeling import Fittable2DModel, Parameter
+from astropy.nddata import Cutout2D, NoOverlapError
+from astropy.table import QTable, Table
+from astropy.wcs import WCS
+
+# ── photutils-allframe imports (PYTHONPATH must point at the fork) ──────────
+import photutils
+from photutils.psf import AllFramePhotometry, GriddedPSFModel
+from photutils.psf.groupers import SourceGrouper
+
+if 'photutils-allframe' not in photutils.__file__:
+    raise RuntimeError(
+        f'photutils is being imported from {photutils.__file__!r}; '
+        'set PYTHONPATH=/blue/adamginsburg/adamginsburg/repos/photutils-allframe '
+        'so the allframe branch is picked up.'
+    )
+
+# ── paths ────────────────────────────────────────────────────────────────────
+
+SICKLE = '/orange/adamginsburg/jwst/sickle'
+PSF_DIR = SICKLE  # nircam_<det>_<filt>_fovp101_samp4_npsf16.fits live here
+REGION_FILE = os.path.join(SICKLE, 'regions_/benchmark_cutout.reg')
+UNION_CAT = os.path.join(SICKLE, 'catalogs/seed_union_iter3_sickle.fits')
+
+OUT_PHOT = os.path.join(os.path.dirname(__file__), 'allframe_cutout_results.fits')
+OUT_FRAMES = os.path.join(os.path.dirname(__file__), 'allframe_cutout_frames.csv')
+
+DET_TOKEN_RE = re.compile(r'_(nrca[1-5]|nrcalong|nrcb[1-4]|nrcblong)_')
+
+# Sickle NIRCam filters (skip MIRI for this demo — different PSF infrastructure)
+# and which detector tokens contribute per filter.
+FILTER_CFG = [
+    # (filter, [detector_tokens], is_long_wavelength)
+    ('f187n', ['nrcb1', 'nrcb2', 'nrcb3', 'nrcb4'], False),
+    ('f210m', ['nrcb1', 'nrcb2', 'nrcb3', 'nrcb4'], False),
+    ('f335m', ['nrcblong'], True),
+    ('f470n', ['nrcblong'], True),
+    ('f480m', ['nrcblong'], True),
+]
+
+
+# ─── region parsing ──────────────────────────────────────────────────────────
+
+def parse_box_region(path):
+    """Parse a single ICRS box() DS9 region. Returns (SkyCoord center,
+    (height, width) Quantity).
+
+    Expected format:
+        icrs
+        box(ra_deg, dec_deg, w_arcsec", h_arcsec", angle)
+    """
+    text = open(path).read()
+    m = re.search(
+        r'box\(\s*([\d\.+-eE]+)\s*,\s*([\d\.+-eE]+)\s*,'
+        r'\s*([\d\.+-eE]+)"\s*,\s*([\d\.+-eE]+)"\s*,\s*([\d\.+-eE]+)\s*\)',
+        text,
+    )
+    if m is None:
+        raise ValueError(f'No box(...) region found in {path}')
+    ra, dec, w_as, h_as, angle = (float(x) for x in m.groups())
+    if angle != 0.0:
+        raise ValueError(
+            f'Rotated box (angle={angle}) not supported by Cutout2D path'
+        )
+    center = SkyCoord(ra=ra * u.deg, dec=dec * u.deg, frame='icrs')
+    # Cutout2D 'size' takes (ny, nx); pass (h, w) in arcsec.
+    size = (h_as * u.arcsec, w_as * u.arcsec)
+    return center, size
+
+
+# ─── PSF wrapper ─────────────────────────────────────────────────────────────
+
+class OffsetGriddedPSF(Fittable2DModel):
+    """Wrap a ``GriddedPSFModel`` with a fixed cutout→detector pixel offset.
+
+    The wrapper exposes ``(x_0, y_0, flux)`` parameters in the *cutout*
+    coordinate system (so it composes naturally with ``AllFramePhotometry``
+    and a cutout-frame WCS). Inside ``evaluate`` we add ``(dx, dy)`` to
+    every input before delegating to the underlying ``GriddedPSFModel``,
+    so the grid is interpolated at the true detector pixel — no fallback,
+    no nearest-neighbour, no average PSF.
+    """
+
+    n_inputs = 2
+    n_outputs = 1
+
+    x_0 = Parameter(default=0.0, description='source x in cutout pixels')
+    y_0 = Parameter(default=0.0, description='source y in cutout pixels')
+    flux = Parameter(default=1.0, description='source flux')
+
+    def __init__(self, base_psf, dx, dy, **kwargs):
+        if not isinstance(base_psf, GriddedPSFModel):
+            raise TypeError(
+                f'base_psf must be a GriddedPSFModel; got {type(base_psf).__name__}'
+            )
+        self._base = base_psf
+        self._dx = float(dx)
+        self._dy = float(dy)
+        super().__init__(**kwargs)
+
+    @property
+    def detector_offset(self):
+        return (self._dx, self._dy)
+
+    def evaluate(self, x, y, x_0, y_0, flux):
+        b = self._base
+        b.x_0 = float(x_0) + self._dx
+        b.y_0 = float(y_0) + self._dy
+        b.flux = float(flux)
+        return b(np.asarray(x) + self._dx, np.asarray(y) + self._dy)
+
+
+# ─── frame loading ───────────────────────────────────────────────────────────
+
+def _det_token(fname):
+    m = DET_TOKEN_RE.search(fname)
+    if m is None:
+        raise ValueError(f'No detector token in {fname}')
+    return m.group(1)
+
+
+def load_frame_cutout(crf_path, center, size):
+    """Read one ``*_crf.fits`` exposure, build the WCS, and cut out the
+    benchmark region.
+
+    Returns
+    -------
+    None if the cutout has no overlap with this frame, otherwise a dict
+    with keys: data, error, wcs, dx, dy, filter, detector, exposure_id,
+    substrt1, substrt2, origin_x, origin_y.
+    """
+    with fits.open(crf_path, memmap=False) as hdul:
+        prim = hdul[0].header
+        sci_hdu = hdul['SCI']
+        sci = sci_hdu.data.astype(np.float64)
+        sci_hdr = sci_hdu.header
+        err_hdu = hdul['ERR']
+        err = err_hdu.data.astype(np.float64)
+
+    # WCS lives on the SCI extension for JWST cal/crf products
+    wcs = WCS(sci_hdr, naxis=2)
+    substrt1 = int(prim.get('SUBSTRT1', sci_hdr.get('SUBSTRT1', 1)))
+    substrt2 = int(prim.get('SUBSTRT2', sci_hdr.get('SUBSTRT2', 1)))
+    filt = prim.get('FILTER') or sci_hdr.get('FILTER')
+    detector = (prim.get('DETECTOR') or sci_hdr.get('DETECTOR')).lower()
+
+    try:
+        sci_cut = Cutout2D(sci, center, size, wcs=wcs, mode='partial',
+                           fill_value=np.nan, copy=True)
+    except NoOverlapError:
+        return None
+    err_cut = Cutout2D(err, center, size, wcs=wcs, mode='partial',
+                       fill_value=np.nan, copy=True)
+
+    # The shift from cutout pixel coordinates to original (subarray) pixel
+    # coordinates is constant: original = cutout + shift. We get it from
+    # the user-supplied centre, which Cutout2D records in both frames.
+    # This is correct in 'partial' mode too, where origin_original gets
+    # clipped at 0 and cannot be used as the shift.
+    pos_orig = np.asarray(sci_cut.input_position_original, dtype=float)
+    pos_cut = np.asarray(sci_cut.input_position_cutout, dtype=float)
+    shift_x, shift_y = pos_orig - pos_cut
+
+    # cutout pixel → full detector pixel
+    dx = shift_x + (substrt1 - 1)
+    dy = shift_y + (substrt2 - 1)
+
+    err_arr = err_cut.data.copy()
+    err_arr[~np.isfinite(err_arr)] = np.inf  # downweight rather than crash
+    err_arr[err_arr <= 0] = np.inf
+
+    exposure_id = os.path.basename(crf_path).replace('.fits', '')
+
+    mask = ~np.isfinite(sci_cut.data)
+
+    return dict(
+        data=sci_cut.data,
+        error=err_arr,
+        mask=mask,
+        wcs=sci_cut.wcs,
+        dx=float(dx),
+        dy=float(dy),
+        filter=filt.lower() if filt else None,
+        detector=detector,
+        exposure_id=exposure_id,
+        substrt1=substrt1,
+        substrt2=substrt2,
+        shift_x=float(shift_x),
+        shift_y=float(shift_y),
+        shape=sci_cut.data.shape,
+    )
+
+
+def load_psf_grid(filt, det_token):
+    """Load the stpsf gridded PSF for (filter, detector)."""
+    psf_path = os.path.join(PSF_DIR,
+                            f'nircam_{det_token}_{filt}_fovp101_samp4_npsf16.fits')
+    if not os.path.exists(psf_path):
+        raise FileNotFoundError(f'Missing stpsf grid: {psf_path}')
+    return GriddedPSFModel.read(psf_path)
+
+
+# ─── init catalog ────────────────────────────────────────────────────────────
+
+def init_sources_in_cutout(center, size):
+    """Return (SkyCoord, ids) of union-catalog sources inside the box.
+
+    The union catalog is the iter3 cross-band master list. We restrict
+    to a slightly enlarged sky box so sources near the cutout edge that
+    still contribute PSF flux are retained.
+    """
+    if not os.path.exists(UNION_CAT):
+        raise FileNotFoundError(
+            f'Union catalog not found at {UNION_CAT} — required for init '
+            'positions; AllFramePhotometry has no built-in finder.'
+        )
+    cat = Table.read(UNION_CAT)
+    cat_sc = SkyCoord(ra=np.asarray(cat['ra'], dtype=float) * u.deg,
+                      dec=np.asarray(cat['dec'], dtype=float) * u.deg)
+    ny, nx = size
+    # 1.1x oversize tolerates edge sources whose PSF wing leaks into the
+    # cutout but whose centre lies just outside. Use the box half-diagonal
+    # as the angular cut, then refine in tangent plane.
+    half_diag = 1.1 * np.hypot(nx.to(u.arcsec).value,
+                               ny.to(u.arcsec).value) / 2.0 * u.arcsec
+    sep = cat_sc.separation(center)
+    keep = sep < half_diag
+    sub = cat[keep]
+    if len(sub) == 0:
+        raise RuntimeError(
+            f'No union-catalog sources fall inside {nx}×{ny} box at '
+            f'({center.ra.deg}, {center.dec.deg})'
+        )
+    sc = SkyCoord(ra=sub['ra'] * u.deg, dec=sub['dec'] * u.deg)
+    return sc, np.asarray(sub['source_id_union'])
+
+
+# ─── main ────────────────────────────────────────────────────────────────────
+
+def collect_frames(center, size):
+    """Walk every configured (filter, detector) and return the per-frame
+    payload list ready for AllFramePhotometry.
+
+    Returns
+    -------
+    frames : list of dict
+        Entries from ``load_frame_cutout`` augmented with ``psf_model``
+        (an ``OffsetGriddedPSF`` carrying this frame's dx/dy).
+    """
+    frames = []
+    grid_cache = {}
+
+    for filt, det_tokens, _ in FILTER_CFG:
+        fdir = os.path.join(SICKLE, filt.upper(), 'pipeline')
+        if not os.path.isdir(fdir):
+            print(f'[skip] {fdir} does not exist', flush=True)
+            continue
+        crfs = sorted(
+            f for f in glob.glob(os.path.join(fdir, '*_crf.fits'))
+            if '_bgsub_' not in os.path.basename(f)
+            and '_iter3_' not in os.path.basename(f)
+        )
+        print(f'[{filt}] {len(crfs)} crf files', flush=True)
+        for crf in crfs:
+            det = _det_token(os.path.basename(crf))
+            if det not in det_tokens:
+                continue
+            payload = load_frame_cutout(crf, center, size)
+            if payload is None:
+                continue
+            if payload['filter'] != filt:
+                raise ValueError(
+                    f'Header FILTER={payload["filter"]!r} disagrees with '
+                    f'directory filter {filt!r} for {crf}'
+                )
+            if payload['detector'] != det:
+                raise ValueError(
+                    f'Header DETECTOR={payload["detector"]!r} disagrees '
+                    f'with filename detector token {det!r} for {crf}'
+                )
+            key = (filt, det)
+            if key not in grid_cache:
+                grid_cache[key] = load_psf_grid(filt, det)
+            base_psf = grid_cache[key]
+            payload['psf_model'] = OffsetGriddedPSF(
+                base_psf, dx=payload['dx'], dy=payload['dy'],
+            )
+            frames.append(payload)
+    return frames
+
+
+def write_frame_log(frames, path):
+    rows = [
+        dict(
+            i=i,
+            filter=f['filter'],
+            detector=f['detector'],
+            exposure_id=f['exposure_id'],
+            ny=f['shape'][0],
+            nx=f['shape'][1],
+            substrt1=f['substrt1'],
+            substrt2=f['substrt2'],
+            shift_x=f['shift_x'],
+            shift_y=f['shift_y'],
+            dx=f['dx'],
+            dy=f['dy'],
+        )
+        for i, f in enumerate(frames)
+    ]
+    Table(rows).write(path, format='csv', overwrite=True)
+
+
+def main():
+    print(f'Reading region {REGION_FILE}', flush=True)
+    center, size = parse_box_region(REGION_FILE)
+    print(f'  center = {center.to_string("hmsdms")}, '
+          f'size = {size[1].to(u.arcsec):.3f} × {size[0].to(u.arcsec):.3f}',
+          flush=True)
+
+    print('Collecting frames + PSFs ...', flush=True)
+    frames = collect_frames(center, size)
+    if not frames:
+        raise RuntimeError('No frames overlap the benchmark cutout.')
+    print(f'  → {len(frames)} frames overlap the cutout', flush=True)
+    write_frame_log(frames, OUT_FRAMES)
+    print(f'  wrote frame log → {OUT_FRAMES}', flush=True)
+
+    sc_init, ids = init_sources_in_cutout(center, size)
+    print(f'Union-catalog sources in cutout: {len(sc_init)}', flush=True)
+
+    init = QTable()
+    init['id'] = ids
+    init['ra'] = sc_init.ra.deg
+    init['dec'] = sc_init.dec.deg
+
+    psf_models = [f['psf_model'] for f in frames]
+    data_list = [f['data'] for f in frames]
+    err_list = [f['error'] for f in frames]
+    mask_list = [f['mask'] for f in frames]
+    wcs_list = [f['wcs'] for f in frames]
+
+    fit_shape_per_frame = [
+        (21, 21) if f['detector'].endswith('long') else (15, 15)
+        for f in frames
+    ]
+    aperture_per_frame = [
+        6.0 if f['detector'].endswith('long') else 4.0
+        for f in frames
+    ]
+
+    print('Building AllFramePhotometry (joint, shared sky positions) ...',
+          flush=True)
+    aff = AllFramePhotometry(
+        psf_models=psf_models,
+        fit_shape=fit_shape_per_frame,
+        aperture_radius=aperture_per_frame,
+        mode='joint',
+        position_frame='sky',
+        share_position=True,
+        grouper=SourceGrouper(min_separation=8),
+        progress_bar=True,
+    )
+
+    print('Fitting ...', flush=True)
+    results = aff(data_list, wcs=wcs_list, errors=err_list,
+                  masks=mask_list, init_params=init)
+    print(f'  → {len(results)} sources fit; columns: {results.colnames}',
+          flush=True)
+
+    results.write(OUT_PHOT, overwrite=True)
+    print(f'Wrote {OUT_PHOT}', flush=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/allframe_cutout_demo.py
+++ b/allframe_cutout_demo.py
@@ -197,7 +197,25 @@ def load_frame_cutout(crf_path, center, size):
     wcs = WCS(sci_hdr, naxis=2)
     substrt1 = int(prim.get('SUBSTRT1', sci_hdr.get('SUBSTRT1', 1)))
     substrt2 = int(prim.get('SUBSTRT2', sci_hdr.get('SUBSTRT2', 1)))
-    filt = prim.get('FILTER') or sci_hdr.get('FILTER')
+    # NIRCam narrow-band filters (F187N, F212N, F405N, F466N, F470N, ...)
+    # sit in the pupil wheel: header FILTER is the wide partner (F444W,
+    # F150W, ...) and PUPIL holds the actual bandpass. Pick whichever
+    # starts with 'F' followed by digits + N/M and treat as the filter.
+    raw_filter = prim.get('FILTER') or sci_hdr.get('FILTER')
+    raw_pupil = prim.get('PUPIL') or sci_hdr.get('PUPIL')
+    candidates = [c for c in (raw_filter, raw_pupil) if c]
+    filt = None
+    for c in candidates:
+        cl = c.lower()
+        if re.fullmatch(r'f\d{3,4}[nmw]', cl):
+            # prefer narrow over wide if both match
+            if filt is None or (cl.endswith('n') and not filt.endswith('n')):
+                filt = cl
+    if filt is None:
+        raise ValueError(
+            f'Cannot determine filter from FILTER={raw_filter!r} '
+            f'PUPIL={raw_pupil!r} in {crf_path}'
+        )
     detector = (prim.get('DETECTOR') or sci_hdr.get('DETECTOR')).lower()
 
     try:
@@ -236,7 +254,7 @@ def load_frame_cutout(crf_path, center, size):
         wcs=sci_cut.wcs,
         dx=float(dx),
         dy=float(dy),
-        filter=filt.lower() if filt else None,
+        filter=filt,
         detector=detector,
         exposure_id=exposure_id,
         substrt1=substrt1,
@@ -247,10 +265,18 @@ def load_frame_cutout(crf_path, center, size):
     )
 
 
+_PSF_DET_MAP = {'nrcalong': 'nrca5', 'nrcblong': 'nrcb5'}
+
+
 def load_psf_grid(filt, det_token):
-    """Load the stpsf gridded PSF for (filter, detector)."""
+    """Load the stpsf gridded PSF for (filter, detector).
+
+    stpsf names long-wavelength grids ``nrca5``/``nrcb5`` while JWST
+    headers and crf filenames use ``nrcalong``/``nrcblong``. Translate.
+    """
+    psf_det = _PSF_DET_MAP.get(det_token, det_token)
     psf_path = os.path.join(PSF_DIR,
-                            f'nircam_{det_token}_{filt}_fovp101_samp4_npsf16.fits')
+                            f'nircam_{psf_det}_{filt}_fovp101_samp4_npsf16.fits')
     if not os.path.exists(psf_path):
         raise FileNotFoundError(f'Missing stpsf grid: {psf_path}')
     return GriddedPSFModel.read(psf_path)
@@ -366,7 +392,33 @@ def write_frame_log(frames, path):
     Table(rows).write(path, format='csv', overwrite=True)
 
 
+def _parse_args():
+    import argparse
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        '--mode', choices=('joint', 'independent'), default='joint',
+        help="AllFramePhotometry mode. 'joint' = shared sky positions "
+             "across all frames (slow). 'independent' = per-frame fits "
+             "stitched together (fast). Default: joint.",
+    )
+    p.add_argument(
+        '--filters', nargs='+', default=None,
+        help='Subset of filters to include (e.g. --filters f187n f210m). '
+             'Default: every filter in FILTER_CFG.',
+    )
+    return p.parse_args()
+
+
 def main():
+    args = _parse_args()
+
+    if args.filters:
+        global FILTER_CFG
+        wanted = {f.lower() for f in args.filters}
+        FILTER_CFG = [(f, d, lw) for (f, d, lw) in FILTER_CFG if f in wanted]
+        if not FILTER_CFG:
+            raise ValueError(f'No matching filters in FILTER_CFG for {wanted}')
+
     print(f'Reading region {REGION_FILE}', flush=True)
     center, size = parse_box_region(REGION_FILE)
     print(f'  center = {center.to_string("hmsdms")}, '
@@ -404,15 +456,15 @@ def main():
         for f in frames
     ]
 
-    print('Building AllFramePhotometry (joint, shared sky positions) ...',
-          flush=True)
+    print(f'Building AllFramePhotometry (mode={args.mode}, sky frame, '
+          f'share_position={args.mode == "joint"}) ...', flush=True)
     aff = AllFramePhotometry(
         psf_models=psf_models,
         fit_shape=fit_shape_per_frame,
         aperture_radius=aperture_per_frame,
-        mode='joint',
+        mode=args.mode,
         position_frame='sky',
-        share_position=True,
+        share_position=(args.mode == 'joint'),
         grouper=SourceGrouper(min_separation=8),
         progress_bar=True,
     )

--- a/allframe_cutout_demo.py
+++ b/allframe_cutout_demo.py
@@ -165,6 +165,24 @@ class OffsetGriddedPSF(Fittable2DModel):
         b.flux = float(flux)
         return b(np.asarray(x) + self._dx, np.asarray(y) + self._dy)
 
+    @property
+    def bounding_box(self):
+        # Half-extent of the underlying gridded PSF in detector pixels =
+        # underlying data shape / 2 / oversampling. The bounding box is
+        # centred on (x_0, y_0) in CUTOUT coordinates; size is detector-
+        # equivalent because the wrapper preserves pixel scale.
+        base = self._base
+        over = np.atleast_1d(np.asarray(getattr(base, 'oversampling', 1)))
+        # oversampling can be scalar or (y, x); use last/first respectively
+        ovx = float(over[-1])
+        ovy = float(over[0])
+        ny, nx = base.data.shape[-2:]
+        half_x = (nx / 2.0) / ovx
+        half_y = (ny / 2.0) / ovy
+        x0 = float(self.x_0.value)
+        y0 = float(self.y_0.value)
+        return ((y0 - half_y, y0 + half_y), (x0 - half_x, x0 + half_x))
+
 
 # ─── frame loading ───────────────────────────────────────────────────────────
 

--- a/test_offset_psf_wrapper.py
+++ b/test_offset_psf_wrapper.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+test_offset_psf_wrapper.py
+
+Sanity check that ``OffsetGriddedPSF`` evaluated in cutout pixel
+coordinates produces exactly the same image as the underlying
+``GriddedPSFModel`` evaluated in detector pixel coordinates (up to the
+constant cutout→detector shift).
+
+Run with the photutils-allframe fork on PYTHONPATH::
+
+    PYTHONPATH=/blue/adamginsburg/adamginsburg/repos/photutils-allframe \\
+        python test_offset_psf_wrapper.py
+"""
+
+import sys
+import numpy as np
+
+sys.path.insert(0, '/orange/adamginsburg/jwst/sickle')
+from allframe_cutout_demo import OffsetGriddedPSF  # noqa: E402
+
+from photutils.psf import GriddedPSFModel  # noqa: E402
+
+
+def _check(grid, det_x, det_y, dx, dy, npix=21, label=''):
+    """Compare wrapped(cutout coords) vs direct(detector coords)."""
+    half = npix // 2
+    # detector-coord eval grid centred on the source
+    yy, xx = np.mgrid[int(round(det_y)) - half:int(round(det_y)) + half + 1,
+                      int(round(det_x)) - half:int(round(det_x)) + half + 1]
+    grid.x_0 = float(det_x)
+    grid.y_0 = float(det_y)
+    grid.flux = 1.0
+    direct = grid(xx, yy)
+
+    # cutout-coord eval grid: same physical pixels, just shifted by (dx, dy)
+    cxx = xx - dx
+    cyy = yy - dy
+
+    wrapper = OffsetGriddedPSF(grid, dx=dx, dy=dy)
+    wrapped = wrapper.evaluate(
+        cxx.astype(float), cyy.astype(float),
+        x_0=det_x - dx, y_0=det_y - dy, flux=1.0,
+    )
+
+    diff = np.abs(direct - wrapped).max()
+    print(f'{label:>20s}: direct sum={direct.sum():.6f}  '
+          f'wrapped sum={wrapped.sum():.6f}  max|diff|={diff:.3e}')
+    if diff > 1e-12:
+        raise AssertionError(
+            f'{label}: OffsetGriddedPSF disagrees with direct GriddedPSFModel '
+            f'at det=({det_x}, {det_y}); max |diff|={diff}'
+        )
+
+
+def main():
+    grid = GriddedPSFModel.read(
+        '/orange/adamginsburg/jwst/sickle/'
+        'nircam_nrcb1_f187n_fovp101_samp4_npsf16.fits'
+    )
+
+    # Integer offset (e.g. cutout from a subarray with integer SUBSTRT and
+    # integer cutout origin): trivial bit-exact match expected.
+    _check(grid, det_x=1235, det_y=1567, dx=1225, dy=1557, label='integer offset')
+    _check(grid, det_x=400, det_y=1800, dx=395, dy=1790, label='another integer')
+
+    # Non-integer source position with integer offset (typical case where
+    # SUBSTRT-1 is integer but the source falls between pixels):
+    _check(grid, det_x=1234.7, det_y=1567.3, dx=1225, dy=1557,
+           label='source mid-pixel')
+
+    # Non-integer offset (Cutout2D position_original - position_cutout can
+    # be fractional if the centre wasn't on a pixel — e.g. partial mode):
+    _check(grid, det_x=1234.7, det_y=1567.3, dx=1224.7, dy=1557.3,
+           label='fractional offset')
+
+    print('OK: wrapper reproduces direct evaluation to machine precision.')
+
+
+if __name__ == '__main__':
+    main()

--- a/test_offset_psf_wrapper.py
+++ b/test_offset_psf_wrapper.py
@@ -13,10 +13,11 @@ Run with the photutils-allframe fork on PYTHONPATH::
         python test_offset_psf_wrapper.py
 """
 
+import os
 import sys
 import numpy as np
 
-sys.path.insert(0, '/orange/adamginsburg/jwst/sickle')
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from allframe_cutout_demo import OffsetGriddedPSF  # noqa: E402
 
 from photutils.psf import GriddedPSFModel  # noqa: E402


### PR DESCRIPTION
**Draft / WIP** — opening so this stale, never-pushed exploratory branch is reviewable instead of lost.

### What it does
DAOPHOT **ALLFRAME**-style cutout photometry demo:
- `AllFramePhotometry` cutout demo with a **detector-aware PSF wrapper**.
- Demo CLI `--mode/--filters`; fix LW grid token + NIRCam pupil filter selection.
- `OffsetGriddedPSF.bounding_box` for `make_residual_image`.

### Current state — NOT ready to merge
- **Stale**: last real commit **2026-05-03**, branch never pushed, **~205 commits behind main**.
- Top commit is salvaged WIP (`test_offset_psf_wrapper.py`); data outputs (`allframe_cutout_frames.csv`, `allframe_cutout_results.fits`) left untracked on purpose.
- Exploratory demo — needs rebase + a decision on whether the ALLFRAME cutout path is still wanted.

### Related memory
- `peppar-sgrb2-run` — peppar (PSF-fit photometry/astrometry) is the **actively-used** PSF-photometry path for Sgr B2 (F212N+F480M, completed 2026-07-17). This ALLFRAME cutout demo is an **alternative** PSF-photometry approach; decide overlap / which to carry forward before investing more here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SCst3zDeoMKhFRjYFeUJd
